### PR TITLE
Add PO ExtraLineItems functionality to API

### DIFF
--- a/inventree/order.py
+++ b/inventree/order.py
@@ -51,7 +51,7 @@ class PurchaseOrder(inventree.base.InventreeObject):
 class PurchaseOrderLineItem(inventree.base.InventreeObject):
     """ Class representing the PurchaseOrderLineItem database model """
 
-    URL = 'order/po-line/'
+    URL = 'order/po-line'
 
     def getSupplierPart(self):
         """
@@ -75,7 +75,7 @@ class PurchaseOrderLineItem(inventree.base.InventreeObject):
 class PurchaseOrderExtraLineItem(inventree.base.InventreeObject):
     """ Class representing the PurchaseOrderExtraLineItem database model """
 
-    URL = 'order/po-extra-line/'
+    URL = 'order/po-extra-line'
 
     def getOrder(self):
         """

--- a/inventree/order.py
+++ b/inventree/order.py
@@ -14,6 +14,10 @@ class PurchaseOrder(inventree.base.InventreeObject):
         """ Return the line items associated with this order """
         return PurchaseOrderLineItem.list(self._api, order=self.pk, **kwargs)
 
+    def getExtraLineItems(self, **kwargs):
+        """ Return the line items associated with this order """
+        return PurchaseOrderExtraLineItem.list(self._api, order=self.pk, **kwargs)
+
     def addLineItem(self, **kwargs):
         """
         Create (and return) new PurchaseOrderLineItem object against this PurchaseOrder
@@ -22,6 +26,15 @@ class PurchaseOrder(inventree.base.InventreeObject):
         kwargs['order'] = self.pk
 
         return PurchaseOrderLineItem.create(self._api, data=kwargs)
+
+    def addExtraLineItem(self, **kwargs):
+        """
+        Create (and return) new PurchaseOrderExtraLineItem object against this PurchaseOrder
+        """
+
+        kwargs['order'] = self.pk
+
+        return PurchaseOrderExtraLineItem.create(self._api, data=kwargs)
 
     def getAttachments(self):
         return PurchaseOrderAttachment.list(self._api, order=self.pk)
@@ -51,6 +64,17 @@ class PurchaseOrderLineItem(inventree.base.InventreeObject):
         Return the Part referenced by the associated SupplierPart
         """
         return inventree.part.Part(self._api, self.getSupplierPart().part)
+
+    def getOrder(self):
+        """
+        Return the PurchaseOrder to which this PurchaseOrderLineItem belongs
+        """
+        return PurchaseOrder(self._api, self.order)
+
+class PurchaseOrderExtraLineItem(inventree.base.InventreeObject):
+    """ Class representing the PurchaseOrderExtraLineItem database model """
+
+    URL = 'order/po-extra-line/'
 
     def getOrder(self):
         """

--- a/inventree/order.py
+++ b/inventree/order.py
@@ -71,6 +71,7 @@ class PurchaseOrderLineItem(inventree.base.InventreeObject):
         """
         return PurchaseOrder(self._api, self.order)
 
+
 class PurchaseOrderExtraLineItem(inventree.base.InventreeObject):
     """ Class representing the PurchaseOrderExtraLineItem database model """
 

--- a/test/test_order.py
+++ b/test/test_order.py
@@ -120,7 +120,7 @@ class POTest(InvenTreeTestCase):
             self.assertEqual(line.getOrder().pk, po.pk)
 
             self.assertIsNotNone(line)
-
+        
             # Assert that a new line item has been created
             self.assertEqual(len(po.getLineItems()), idx)
 
@@ -133,12 +133,10 @@ class POTest(InvenTreeTestCase):
         for idx, line in enumerate(po.getLineItems()):
             self.assertEqual(line.quantity, idx + 1)
             self.assertEqual(line.received, 0)
-        
-        # Delete the last line item as a test
-        line.delete()
+            line.delete()
         
         # Assert length is now one less than before
-        self.assertEqual(len(po.getLineItems()), idx - 1)
+        self.assertEqual(len(po.getLineItems()), 0)
         
         # Should not be any extra-line-items yet!
         extraitems = po.getExtraLineItems()
@@ -158,7 +156,7 @@ class POTest(InvenTreeTestCase):
         extraline.delete()
         
         # Now there should be 0 lines left
-        self.assertEqual(po.getExtraLineItems(), 0)
+        self.assertEqual(len(po.getExtraLineItems()), 0)
 
     def test_purchase_order_delete(self):
         """

--- a/test/test_order.py
+++ b/test/test_order.py
@@ -138,14 +138,14 @@ class POTest(InvenTreeTestCase):
         line.delete()
         
         # Assert length is now one less than before
-        self.assertEqual(len(po.getLineItems()), idx-1)
+        self.assertEqual(len(po.getLineItems()), idx - 1)
         
         # Should not be any extra-line-items yet!
         extraitems = po.getExtraLineItems()
         self.assertEqual(len(extraitems), 0)
         
         # Let's add some!
-        extraline = po.addExtraLineItem(quantity = 1, reference = "Transport costs", notes="Extra line item added from Python interface",price=10,price_currency="EUR")
+        extraline = po.addExtraLineItem(quantity=1, reference="Transport costs", notes="Extra line item added from Python interface", price=10, price_currency="EUR")
         
         self.assertEqual(extraline.getOrder().pk, po.pk)
 

--- a/test/test_order.py
+++ b/test/test_order.py
@@ -133,6 +133,20 @@ class POTest(InvenTreeTestCase):
         for idx, line in enumerate(po.getLineItems()):
             self.assertEqual(line.quantity, idx + 1)
             self.assertEqual(line.received, 0)
+        
+        # Should not be any extra-line-items yet!
+        extraitems = po.getExtraLineItems()
+        self.assertEqual(len(extraitems), 0)
+        
+        # Let's add some!
+        extraline = po.addExtraLineItem(quantity = 1, reference = "Transport costs", notes="Extra line item added from Python interface",price=10,price_currency="EUR")
+        
+        self.assertEqual(extraline.getOrder().pk, po.pk)
+
+        self.assertIsNotNone(extraline)
+        
+        # Assert that a new line item has been created
+        self.assertEqual(len(po.getExtraLineItems()), 1)
 
     def test_purchase_order_delete(self):
         """

--- a/test/test_order.py
+++ b/test/test_order.py
@@ -134,6 +134,12 @@ class POTest(InvenTreeTestCase):
             self.assertEqual(line.quantity, idx + 1)
             self.assertEqual(line.received, 0)
         
+        # Delete the last line item as a test
+        line.delete()
+        
+        # Assert length is now one less than before
+        self.assertEqual(len(po.getLineItems()), idx-1)
+        
         # Should not be any extra-line-items yet!
         extraitems = po.getExtraLineItems()
         self.assertEqual(len(extraitems), 0)
@@ -147,6 +153,12 @@ class POTest(InvenTreeTestCase):
         
         # Assert that a new line item has been created
         self.assertEqual(len(po.getExtraLineItems()), 1)
+        
+        # Assert that we can delete the item again
+        extraline.delete()
+        
+        # Now there should be 0 lines left
+        self.assertEqual(po.getExtraLineItems(), 0)
 
     def test_purchase_order_delete(self):
         """


### PR DESCRIPTION
I have copied the relevant functions for PO Line items so that they work for extra line items as well.

These were previously missing from the python API