### PR TITLE
Increase server request timeout to 10s

### DIFF
--- a/inventree/api.py
+++ b/inventree/api.py
@@ -226,7 +226,7 @@ class InvenTreeAPI(object):
                 headers=headers,
                 json=json,
                 files=files,
-                timeout=2.5,
+                timeout=10,
             )
         except Exception as e:
             # Re-thrown any caught errors, and add a message to the log


### PR DESCRIPTION
The timeout is easily reached when running `company.getSuppliedParts()` with a company having 300+ supplied parts.