### PR TITLE
Add tests for Part Parameters and ParameterTemplates

### DIFF
--- a/test/test_part.py
+++ b/test/test_part.py
@@ -13,7 +13,7 @@ sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 
 from test_api import InvenTreeTestCase  # noqa: E402
 
-from inventree.part import Part, PartAttachment, PartCategory  # noqa: E402
+from inventree.part import Part, PartAttachment, PartCategory, Parameter, ParameterTemplate  # noqa: E402
 from inventree.part import InternalPrice  # noqa: E402
 
 

--- a/test/test_part.py
+++ b/test/test_part.py
@@ -432,19 +432,19 @@ class PartTest(InvenTreeTestCase):
         existingTemplates = len(ParameterTemplate.list(self.api))
         
         # Create new parameter template - this will fail, no name given
-        parametertemplate = ParameterTemplate.create(self.api, data={'units':"kg A"})
+        parametertemplate = ParameterTemplate.create(self.api, data={'units': "kg A"})
         
         # result should be None
         self.assertIsNone(parametertemplate)
         
         # Now create a proper parameter template
-        parametertemplate = ParameterTemplate.create(self.api, data={'name':'Test parameter','units':"kg A"})
+        parametertemplate = ParameterTemplate.create(self.api, data={'name': f'Test parameter no {existingTemplates}', 'units': "kg A"})
         
         # result should not be None
         self.assertIsNotNone(parametertemplate)
         
         # Count should be one higher now
-        self.assertEqual(len(ParameterTemplate.list(self.api)), existingTemplates+1)
+        self.assertEqual(len(ParameterTemplate.list(self.api)), existingTemplates + 1)
         
         # Grab the first part
         p = Part.list(self.api)[0]
@@ -453,41 +453,35 @@ class PartTest(InvenTreeTestCase):
         existingParameters = len(p.getParameters())
         
         # Define parameter value for this part - without all required values
-        param = Parameter.create(self.api, data={'part':p.pk, 'template':parametertemplate.pk})
+        param = Parameter.create(self.api, data={'part': p.pk, 'template': parametertemplate.pk})
         
         # result should be None
         self.assertIsNone(param)
         
         # Define parameter value for this part - without all required values
-        param = Parameter.create(self.api, data={'part':p.pk, 'data':10})
+        param = Parameter.create(self.api, data={'part': p.pk, 'data': 10})
         
         # result should be None
         self.assertIsNone(param)
         
         # Define w. required values - integer
-        param = Parameter.create(self.api, data={'part':p.pk, 'template':parametertemplate.pk,'data':10})
+        param = Parameter.create(self.api, data={'part': p.pk, 'template': parametertemplate.pk, 'data': 10})
         
         # result should not be None
         self.assertIsNotNone(param)
         
         # Same parameter for same part - should fail
         # Define w. required values - string
-        param2 = Parameter.create(self.api, data={'part':p.pk, 'template':parametertemplate.pk,'data':'String value'})
+        param2 = Parameter.create(self.api, data={'part': p.pk, 'template': parametertemplate.pk, 'data': 'String value'})
         
         # result should be None
         self.assertIsNone(param2)
         
         # Number of parameters should be one higher than before
-        self.assertEqual(len(p.getParameters()), existingParameters+1)
+        self.assertEqual(len(p.getParameters()), existingParameters + 1)
         
         # Delete the parameter
         param.delete()
         
         # Check count
         self.assertEqual(len(p.getParameters()), existingParameters)
-        
-        # Delete the parameter template
-        parametertemplate.delete()
-        
-        # Check count
-        self.assertEqual(len(ParameterTemplate.list(self.api)), existingTemplates)

--- a/test/test_part.py
+++ b/test/test_part.py
@@ -453,29 +453,29 @@ class PartTest(InvenTreeTestCase):
         existingParameters = len(p.getParameters())
         
         # Define parameter value for this part - without all required values
-        param = Parameter.create(self.api, data={'template':parametertemplate.pk})
+        param = Parameter.create(self.api, data={'part':p.pk, 'template':parametertemplate.pk})
         
         # result should be None
         self.assertIsNone(param)
         
         # Define parameter value for this part - without all required values
-        param = Parameter.create(self.api, data={'data':10})
+        param = Parameter.create(self.api, data={'part':p.pk, 'data':10})
         
         # result should be None
         self.assertIsNone(param)
         
         # Define w. required values - integer
-        param = Parameter.create(self.api, data={'template':parametertemplate.pk,'data':10})
+        param = Parameter.create(self.api, data={'part':p.pk, 'template':parametertemplate.pk,'data':10})
         
         # result should not be None
         self.assertIsNotNone(param)
         
         # Same parameter for same part - should fail
         # Define w. required values - string
-        param = Parameter.create(self.api, data={'template':parametertemplate.pk,'data':'String value'})
+        param2 = Parameter.create(self.api, data={'part':p.pk, 'template':parametertemplate.pk,'data':'String value'})
         
         # result should be None
-        self.assertIsNone(param)
+        self.assertIsNone(param2)
         
         # Number of parameters should be one higher than before
         self.assertEqual(len(p.getParameters()), existingParameters+1)

--- a/test/test_part.py
+++ b/test/test_part.py
@@ -422,3 +422,72 @@ class PartTest(InvenTreeTestCase):
         self.assertEqual(ip.part, p.pk)
         ip_price_clean = float(ip.price)
         self.assertEqual(ip_price_clean, test_price)
+
+    def test_parameters(self):
+        """
+        Test setting and getting Part parameter templates, as well as parameter values
+        """
+        
+        # Count number of existing Parameter Templates
+        existingTemplates = len(ParameterTemplate.list(self.api))
+        
+        # Create new parameter template - this will fail, no name given
+        parametertemplate = ParameterTemplate.create(self.api, data={'units':"kg A"})
+        
+        # result should be None
+        self.assertIsNone(parametertemplate)
+        
+        # Now create a proper parameter template
+        parametertemplate = ParameterTemplate.create(self.api, data={'name':'Test parameter','units':"kg A"})
+        
+        # result should not be None
+        self.assertIsNotNone(parametertemplate)
+        
+        # Count should be one higher now
+        self.assertEqual(len(ParameterTemplate.list(self.api)), existingTemplates+1)
+        
+        # Grab the first part
+        p = Part.list(self.api)[0]
+        
+        # Count number of parameters
+        existingParameters = len(p.getParameters())
+        
+        # Define parameter value for this part - without all required values
+        param = Parameter.create(self.api, data={'template':parametertemplate.pk})
+        
+        # result should be None
+        self.assertIsNone(param)
+        
+        # Define parameter value for this part - without all required values
+        param = Parameter.create(self.api, data={'data':10})
+        
+        # result should be None
+        self.assertIsNone(param)
+        
+        # Define w. required values - integer
+        param = Parameter.create(self.api, data={'template':parametertemplate.pk,'data':10})
+        
+        # result should not be None
+        self.assertIsNotNone(param)
+        
+        # Same parameter for same part - should fail
+        # Define w. required values - string
+        param = Parameter.create(self.api, data={'template':parametertemplate.pk,'data':'String value'})
+        
+        # result should be None
+        self.assertIsNone(param)
+        
+        # Number of parameters should be one higher than before
+        self.assertEqual(len(p.getParameters()), existingParameters+1)
+        
+        # Delete the parameter
+        param.delete()
+        
+        # Check count
+        self.assertEqual(len(p.getParameters()), existingParameters)
+        
+        # Delete the parameter template
+        parametertemplate.delete()
+        
+        # Check count
+        self.assertEqual(len(ParameterTemplate.list(self.api)), existingTemplates)


### PR DESCRIPTION
Adds a few tests for Parameter and ParameterTemplate classes.

While making these tests, I realised that there is no ParameterTemplate.delete() support by the API.