### PR TITLE
Test for deleting parametertemplates

### DIFF
--- a/test/test_part.py
+++ b/test/test_part.py
@@ -490,4 +490,4 @@ class PartTest(InvenTreeTestCase):
         parametertemplate.delete()
         
         # Check count
-        self.assertEqual(len(ParameterTemplate.list(self.api), existingTemplates)
+        self.assertEqual(len(ParameterTemplate.list(self.api)), existingTemplates)

--- a/test/test_part.py
+++ b/test/test_part.py
@@ -485,3 +485,9 @@ class PartTest(InvenTreeTestCase):
         
         # Check count
         self.assertEqual(len(p.getParameters()), existingParameters)
+        
+        # Delete the parameter template
+        parametertemplate.delete()
+        
+        # Check count
+        self.assertEqual(len(ParameterTemplate.list(self.api), existingTemplates)


### PR DESCRIPTION
This was missing in PR #107 because the ParameterTemplate delete functionality was not implemented in the back end.
Now that it is (see [this PR](https://github.com/inventree/InvenTree/pull/3123)), this can be added again.