### PR TITLE
Add ExtraLine functions for Sales Order

### DIFF
--- a/inventree/order.py
+++ b/inventree/order.py
@@ -101,6 +101,10 @@ class SalesOrder(inventree.base.InventreeObject):
         """ Return the line items associated with this order """
         return SalesOrderLineItem.list(self._api, order=self.pk, **kwargs)
 
+    def getExtraLineItems(self, **kwargs):
+        """ Return the line items associated with this order """
+        return SalesOrderExtraLineItem.list(self._api, order=self.pk, **kwargs)
+
     def addLineItem(self, **kwargs):
         """
         Create (and return) new SalesOrderLineItem object against this SalesOrder
@@ -109,6 +113,15 @@ class SalesOrder(inventree.base.InventreeObject):
         kwargs['order'] = self.pk
 
         return SalesOrderLineItem.create(self._api, data=kwargs)
+
+    def addExtraLineItem(self, **kwargs):
+        """
+        Create (and return) new SalesOrderExtraLineItem object against this SalesOrder
+        """
+
+        kwargs['order'] = self.pk
+
+        return SalesOrderExtraLineItem.create(self._api, data=kwargs)
 
     def getAttachments(self):
         return SalesOrderAttachment.list(self._api, order=self.pk)
@@ -132,6 +145,18 @@ class SalesOrderLineItem(inventree.base.InventreeObject):
         Return the Part object referenced by this SalesOrderLineItem
         """
         return inventree.part.Part(self._api, self.part)
+
+    def getOrder(self):
+        """
+        Return the SalesOrder to which this SalesOrderLineItem belongs
+        """
+        return SalesOrder(self._api, self.order)
+
+
+class SalesOrderExtraLineItem(inventree.base.InventreeObject):
+    """ Class representing the SalesOrderExtraLineItem database model """
+
+    URL = 'order/so-extra-line'
 
     def getOrder(self):
         """

--- a/test/test_order.py
+++ b/test/test_order.py
@@ -293,6 +293,25 @@ class SOTest(InvenTreeTestCase):
 
                 self.assertEqual(len(sales_order.getLineItems()), idx + 1)
 
+            # Should not be any extra-line-items yet!
+            self.assertEqual(len(sales_order.getExtraLineItems()), 0)
+
+            # Let's add some!
+            extraline = sales_order.addExtraLineItem(quantity=1, reference="Transport costs", notes="Extra line item added from Python interface", price=10, price_currency="EUR")
+
+            self.assertIsNotNone(extraline)
+
+            self.assertEqual(extraline.getOrder().pk, sales_order.pk)
+
+            # Assert that a new line item has been created
+            self.assertEqual(len(sales_order.getExtraLineItems()), 1)
+
+            # Assert that we can delete the item again
+            extraline.delete()
+
+            # Now there should be 0 lines left
+            self.assertEqual(len(sales_order.getExtraLineItems()), 0)
+
     def test_so_attachment(self):
         """
         Test upload of attachment against a SalesOrder


### PR DESCRIPTION
The Sales Order classes were missing the ExtraLineItems functions; these have been copied from PurchaseOrder templates.

Tests for adding and deleting a sales order extra line item added