### PR TITLE
Add support for simple parsing of paginated response

### DIFF
--- a/inventree/base.py
+++ b/inventree/base.py
@@ -137,7 +137,7 @@ class InventreeObject(object):
         items = []
 
         if isinstance(response, dict) and response['results'] is not None:
-          response = response['results']
+            response = response['results']
 
         for data in response:
             if 'pk' in data:

--- a/inventree/base.py
+++ b/inventree/base.py
@@ -136,6 +136,9 @@ class InventreeObject(object):
 
         items = []
 
+        if isinstance(response, dict) and response['results'] is not None:
+          response = response['results']
+
         for data in response:
             if 'pk' in data:
                 items.append(cls(data=data, api=api))


### PR DESCRIPTION
When adding the limit= parameter to list it causes InvenTree to modify the output of the rest response to be a dict instead of a simple array of results. Inside of that dict includes a results array that inventree-python is actually looking for. Without this addition inventree-python will ignore the result and return an empty result set.