### PR TITLE
Category template fix

### DIFF
--- a/inventree/part.py
+++ b/inventree/part.py
@@ -43,7 +43,7 @@ class PartCategory(inventree.base.MetadataMixin, inventree.base.InventreeObject)
     def getChildCategories(self, **kwargs):
         return PartCategory.list(self._api, parent=self.pk, **kwargs)
 
-    def getCategoryParameterTemplates(self, fetch_parent: bool = True) -> list[PartCategoryParameterTemplate]:
+    def getCategoryParameterTemplates(self, fetch_parent: bool = True) -> list:
         """Fetch a list of default parameter templates associated with this category
 
         Arguments:

--- a/inventree/part.py
+++ b/inventree/part.py
@@ -43,16 +43,18 @@ class PartCategory(inventree.base.MetadataMixin, inventree.base.InventreeObject)
     def getChildCategories(self, **kwargs):
         return PartCategory.list(self._api, parent=self.pk, **kwargs)
 
-    def get_category_parameter_templates(self, fetch_parent=True):
-        """
-            fetch_parent: enable to fetch templates for parent categories
+    def getCategoryParameterTemplates(self, fetch_parent: bool = True) -> list[PartCategoryParameterTemplate]:
+        """Fetch a list of default parameter templates associated with this category
+
+        Arguments:
+            fetch_parent: If True (default) include templates for parents also
         """
 
-        parameters_url = f'part/category/{self.pk}/parameters'
-
-        return self.list(self._api,
-                         url=parameters_url,
-                         fetch_parent=fetch_parent)
+        return PartCategoryParameterTemplate.list(
+            self._api,
+            category=self.pk,
+            fetch_parent=fetch_parent
+        )
 
 
 class Part(inventree.base.MetadataMixin, inventree.base.ImageMixin, inventree.base.InventreeObject):

--- a/inventree/part.py
+++ b/inventree/part.py
@@ -12,6 +12,20 @@ import inventree.build
 logger = logging.getLogger('inventree')
 
 
+class PartCategoryParameterTemplate(inventree.base.InventreeObject):
+    """A model which link a ParameterTemplate to a PartCategory"""
+
+    URL = 'part/category/parameters'
+
+    def getCategory(self):
+        """Return the referenced PartCategory instance"""
+        return PartCategory(self._api, self.category)
+    
+    def getTemplate(self):
+        """Return the referenced ParameterTemplate instance"""
+        return ParameterTemplate(self._api, self.parameter_template)
+
+
 class PartCategory(inventree.base.MetadataMixin, inventree.base.InventreeObject):
     """ Class representing the PartCategory database model """
 

--- a/test/test_part.py
+++ b/test/test_part.py
@@ -15,67 +15,12 @@ sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 
 from test_api import InvenTreeTestCase  # noqa: E402
 
-from inventree.part import Part, PartAttachment, PartCategory, Parameter, ParameterTemplate  # noqa: E402
+from inventree.part import Part, PartAttachment, PartCategory, PartCategoryParameterTemplate, Parameter, ParameterTemplate  # noqa: E402
 from inventree.part import InternalPrice  # noqa: E402
 
 
-class PartTest(InvenTreeTestCase):
-    """
-    Test for PartCategory and Part objects.
-    """
-
-    def test_access_erors(self):
-        """
-        Test that errors are flagged when we try to access an invalid part
-        """
-
-        with self.assertRaises(TypeError):
-            Part(self.api, 'hello')
-        
-        with self.assertRaises(ValueError):
-            Part(self.api, -1)
-
-        # Try to access a Part which does not exist
-        with self.assertRaises(requests.exceptions.HTTPError):
-            Part(self.api, 9999999999999)
-
-    def test_fields(self):
-        """
-        Test field names via OPTIONS request
-        """
-
-        field_names = Part.fieldNames(self.api)
-
-        self.assertIn('active', field_names)
-        self.assertIn('revision', field_names)
-        self.assertIn('full_name', field_names)
-        self.assertIn('IPN', field_names)
-
-    def test_options(self):
-        """Extends tests for OPTIONS model metadata"""
-
-        # Check for field which does not exist
-        with self.assertLogs():
-            Part.fieldInfo('abcde', self.api)
-
-        active = Part.fieldInfo('active', self.api)
-
-        self.assertEqual(active['type'], 'boolean')
-        self.assertEqual(active['required'], True)
-        self.assertEqual(active['label'], 'Active')
-        self.assertEqual(active['default'], True)
-
-        for field_name in [
-            'name',
-            'description',
-            'component',
-            'assembly',
-        ]:
-            field = Part.fieldInfo(field_name, self.api)
-
-            # Check required field attributes
-            for attr in ['type', 'required', 'read_only', 'label', 'help_text']:
-                self.assertIn(attr, field)
+class PartCategoryTest(InvenTreeTestCase):
+    """Tests for PartCategory models"""
 
     def test_part_cats(self):
         """
@@ -172,6 +117,62 @@ class PartTest(InvenTreeTestCase):
         parts = cat.getParts()
 
         self.assertEqual(len(parts), n_parts + 10)
+
+class PartTest(InvenTreeTestCase):
+    """Tests for Part models"""
+
+    def test_access_erors(self):
+        """
+        Test that errors are flagged when we try to access an invalid part
+        """
+
+        with self.assertRaises(TypeError):
+            Part(self.api, 'hello')
+        
+        with self.assertRaises(ValueError):
+            Part(self.api, -1)
+
+        # Try to access a Part which does not exist
+        with self.assertRaises(requests.exceptions.HTTPError):
+            Part(self.api, 9999999999999)
+
+    def test_fields(self):
+        """
+        Test field names via OPTIONS request
+        """
+
+        field_names = Part.fieldNames(self.api)
+
+        self.assertIn('active', field_names)
+        self.assertIn('revision', field_names)
+        self.assertIn('full_name', field_names)
+        self.assertIn('IPN', field_names)
+
+    def test_options(self):
+        """Extends tests for OPTIONS model metadata"""
+
+        # Check for field which does not exist
+        with self.assertLogs():
+            Part.fieldInfo('abcde', self.api)
+
+        active = Part.fieldInfo('active', self.api)
+
+        self.assertEqual(active['type'], 'boolean')
+        self.assertEqual(active['required'], True)
+        self.assertEqual(active['label'], 'Active')
+        self.assertEqual(active['default'], True)
+
+        for field_name in [
+            'name',
+            'description',
+            'component',
+            'assembly',
+        ]:
+            field = Part.fieldInfo(field_name, self.api)
+
+            # Check required field attributes
+            for attr in ['type', 'required', 'read_only', 'label', 'help_text']:
+                self.assertIn(attr, field)
 
     def test_pagination(self):
         """ Test that we can paginate the queryset by specifying a 'limit' parameter"""

--- a/test/test_part.py
+++ b/test/test_part.py
@@ -133,7 +133,7 @@ class PartCategoryTest(InvenTreeTestCase):
                     'units': 'uu',
                 })
 
-                PartCategoryParameterTemplate.create(
+                pcpt = PartCategoryParameterTemplate.create(
                     self.api,
                     data={
                         'category': electronics.pk,
@@ -141,6 +141,10 @@ class PartCategoryTest(InvenTreeTestCase):
                         'default_value': name,
                     }
                 )
+
+                # Check that model lookup functions work
+                self.assertEqual(pcpt.getCategory().pk, electronics.pk)
+                self.assertEqual(pcpt.getTemplate().pk, template.pk)
 
             # Reload
             templates = electronics.getCategoryParameterTemplates(fetch_parent=False)

--- a/test/test_part.py
+++ b/test/test_part.py
@@ -118,6 +118,45 @@ class PartCategoryTest(InvenTreeTestCase):
 
         self.assertEqual(len(parts), n_parts + 10)
 
+    def test_part_category_parameter_templates(self):
+        """Unit tests for the PartCategoryParameterTemplate model"""
+
+        electronics = PartCategory(self.api, pk=3)
+
+        # Ensure there are some parameter templates associated with this category
+        templates = electronics.getCategoryParameterTemplates(fetch_parent=False)
+
+        if len(templates) == 0:
+            for name in ['wodth', 'lungth', 'herght']:
+                template = ParameterTemplate.create(self.api, data={
+                    'name': name,
+                    'units': 'uu',
+                })
+
+                PartCategoryParameterTemplate.create(
+                    self.api,
+                    data={
+                        'category': electronics.pk,
+                        'parameter_template': template.pk,
+                        'default_value': name,
+                    }
+                )
+
+            # Reload
+            templates = electronics.getCategoryParameterTemplates(fetch_parent=False)
+
+        self.assertTrue(len(templates) >= 3)
+
+        # Check child categories
+        childs = electronics.getChildCategories()
+
+        self.assertTrue(len(childs) > 0)
+
+        for child in childs:
+            child_templates = child.getCategoryParameterTemplates(fetch_parent=True)
+            self.assertTrue(len(child_templates) >= 3)
+
+
 class PartTest(InvenTreeTestCase):
     """Tests for Part models"""
 


### PR DESCRIPTION
Adds (or fixes) support for PartCategoryParameterTemplate class

Fixes https://github.com/inventree/inventree-python/issues/131

Note that the method `get_category_parameter_templates` has been renamed to `getCategoryParameterTemplates`