### PR TITLE
Stop server when resetting during tests

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -127,7 +127,7 @@ def test(c, source=None, update=False, reset=False, debug=False):
     Performs the following steps:
 
     - Ensure the docker container is up and running
-    - Reset the database to a known state
+    - Reset the database to a known state (if --reset flag is given)
     - Perform unit testing
     """
 

--- a/tasks.py
+++ b/tasks.py
@@ -121,6 +121,16 @@ def start_server(c, debug=False):
 
 
 @task
+def stop_server(c, debug=False):
+    """
+    Stop a running InvenTree test server docker container
+    """
+
+    # Stop the server
+    c.run('docker-compose -f test/docker-compose.yml down', hide=None if debug else 'both')
+
+
+@task
 def test(c, source=None, update=False, reset=False, debug=False):
     """
     Run the unit tests for the python bindings.
@@ -145,6 +155,7 @@ def test(c, source=None, update=False, reset=False, debug=False):
         update_image(c, debug=debug)
 
     if reset:
+        stop_server(c, debug=debug)
         reset_data(c, debug=debug)
     
     # Launch the InvenTree server (dockerized)


### PR DESCRIPTION
I often have problems that the test server does not come up after a series of tests.

This change, which makes the docker containers go down before resetting the data in them, seems to solve these issues. I also added a note in the docstring about the --reset flag (to clarify behaviour).

