### PR TITLE
Fix label printing

### DIFF
--- a/inventree/api.py
+++ b/inventree/api.py
@@ -490,7 +490,7 @@ class InvenTreeAPI(object):
 
         return data
 
-    def downloadFile(self, url, destination, overwrite=False):
+    def downloadFile(self, url, destination, overwrite=False, params=None):
         """
         Download a file from the InvenTree server.
 
@@ -526,7 +526,7 @@ class InvenTreeAPI(object):
             headers = {}
             auth = self.auth
 
-        with requests.get(url, stream=True, auth=auth, headers=headers) as response:
+        with requests.get(url, stream=True, auth=auth, headers=headers, params=params) as response:
 
             # Error code
             if response.status_code >= 300:

--- a/inventree/label.py
+++ b/inventree/label.py
@@ -32,14 +32,17 @@ class LabelPrintingMixing:
             label_id = label
 
         # Set URL to use
-        URL = f'label/{self.LABELNAME}/{label_id}/print/?{self.LABELITEM}[]={self.pk}'
+        URL = f'label/{self.LABELNAME}/{label_id}/print/'
+        params = {
+            f'{self.LABELITEM}[]': self.pk
+        }
 
         if plugin is not None:
             # Append profile
-            URL += f'&plugin={plugin}'
+            params['plugin'] = plugin
 
             # Get response
-            return self._api.get(URL)
+            return self._api.get(URL, params=params)
 
         if destination is not None:
             if os.path.exists(destination) and os.path.isdir(destination):
@@ -51,7 +54,7 @@ class LabelPrintingMixing:
                 )
 
             # Use downloadFile method to get the file
-            return self._api.downloadFile(url=f'api/{URL}', destination=destination, *args, **kwargs)
+            return self._api.downloadFile(url=f'api/{URL}', destination=destination, params=params, *args, **kwargs)
 
         return False
 


### PR DESCRIPTION
The label printing did format the url parameters directly into the string. While this works fine for the download case, the normal api calls will force a trailing slash breaking this.

The patch fixed it, by passing the parameters as an explicit params dictionary.