### PR TITLE
Add tests for Part functions

### DIFF
--- a/inventree/part.py
+++ b/inventree/part.py
@@ -203,29 +203,23 @@ class PartRelated(inventree.base.InventreeObject):
 
     @classmethod
     def add_related(cls, api, part1, part2):
-    
-        if isinstance(part1,Part):
+
+        if isinstance(part1, Part):
             pk_1 = part1.pk
         else:
             pk_1 = int(part1)
-        if isinstance(part2,Part):
+        if isinstance(part2, Part):
             pk_2 = part2.pk
         else:
             pk_2 = int(part2)
-        
-    
+
         data = {
             'part_1': pk_1,
             'part_2': pk_2,
         }
+
         # Send the data to the server
-        if api.post(cls.URL, data):
-            logging.info("Related OK")
-            ret = True
-        else:
-            logging.warning("Related failed")
-            ret = False
-        return ret
+        return api.post(cls.URL, data)
 
 
 class Parameter(inventree.base.InventreeObject):

--- a/inventree/part.py
+++ b/inventree/part.py
@@ -204,9 +204,19 @@ class PartRelated(inventree.base.InventreeObject):
     @classmethod
     def add_related(cls, api, part1, part2):
     
+        if isinstance(part1,Part):
+            pk_1 = part1.pk
+        else:
+            pk_1 = int(part1)
+        if isinstance(part2,Part):
+            pk_2 = part2.pk
+        else:
+            pk_2 = int(part2)
+        
+    
         data = {
-            'part_1': part1,
-            'part_2': part2,
+            'part_1': pk_1,
+            'part_2': pk_2,
         }
         # Send the data to the server
         if api.post(cls.URL, data):

--- a/inventree/part.py
+++ b/inventree/part.py
@@ -77,7 +77,10 @@ class Part(inventree.base.BarcodeMixin, inventree.base.MetadataMixin, inventree.
 
     def getSupplierParts(self):
         """ Return the supplier parts associated with this part """
-        return inventree.company.SupplierPart.list(self._api, part=self.pk)
+        if self.purchaseable:
+            return inventree.company.SupplierPart.list(self._api, part=self.pk)
+        else:
+            return list()
 
     def getBomItems(self, **kwargs):
         """ Return the items required to make this part """
@@ -220,11 +223,9 @@ class Parameter(inventree.base.InventreeObject):
     URL = 'part/parameter'
 
     def getunits(self):
-        """ Get the dimension and units for this parameter """
+        """ Get the units for this parameter """
 
-        return [element for element
-                in ParameterTemplate.list(self._api)
-                if element['pk'] == self._data['template']]
+        return self._data['template_detail']['units']
 
 
 class ParameterTemplate(inventree.base.InventreeObject):

--- a/test/test_part.py
+++ b/test/test_part.py
@@ -15,7 +15,10 @@ sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 
 from test_api import InvenTreeTestCase  # noqa: E402
 
-from inventree.part import Part, PartAttachment, PartCategory, PartCategoryParameterTemplate, Parameter, ParameterTemplate  # noqa: E402
+from inventree.build import Build
+from inventree.company import SupplierPart
+from inventree.stock import StockItem
+from inventree.part import Part, PartAttachment, PartCategory, PartCategoryParameterTemplate, Parameter, ParameterTemplate, PartTestTemplate, PartRelated, BomItem  # noqa: E402
 from inventree.part import InternalPrice  # noqa: E402
 
 
@@ -166,6 +169,36 @@ class PartCategoryTest(InvenTreeTestCase):
 
 class PartTest(InvenTreeTestCase):
     """Tests for Part models"""
+
+    def test_part_get_functions(self):
+        """Test various functions of Part class, mostly starting with get...
+        These are wrappers for other functions, so the testing of details of the function should
+        be done elsewhere."""
+
+        # Get list of parts
+        parts = Part.list(self.api)
+
+        # For each part in list, test some functions
+        for p in parts:
+            functions = {
+                'getSupplierParts': SupplierPart,
+                'getBomItems': BomItem,
+                'isUsedIn': BomItem,
+                'getBuilds': Build,
+                'getStockItems': StockItem,
+                'getParameters': Parameter,
+                'getRelated': PartRelated,
+                'getInternalPriceList': InternalPrice,
+                'getAttachments': PartAttachment,
+            }
+            for fnc,res in functions.items():
+                A = getattr(p,fnc)()
+                # Make sure a list is returned
+                self.assertIsInstance(A,list)
+                for a in A:
+                    # Make sure any result is of the right class
+                    self.assertIsInstance(a,res)
+
 
     def test_access_erors(self):
         """
@@ -544,7 +577,10 @@ class PartTest(InvenTreeTestCase):
         
         # Define w. required values - integer
         param = Parameter.create(self.api, data={'part': p.pk, 'template': parametertemplate.pk, 'data': 10})
-        
+
+        # Unit should be equal
+        self.assertEqual(param.getunits(),'kg A')
+
         # result should not be None
         self.assertIsNotNone(param)
         
@@ -660,3 +696,17 @@ class PartBarcodeTest(InvenTreeTestCase):
         # Scanning this time should yield no results
         with self.assertRaises(HTTPError):
             response = self.api.scanBarcode(barcode)
+
+
+class PartTestTemplateTest(InvenTreeTestCase):
+    """Tests for PartTestTemplate functionality"""
+    
+    def test_generateKey(self):
+        """Tests for generating a key for a PartTestTemplate"""
+
+        self.assertEqual(PartTestTemplate.generateTestKey('bob'),'bob')
+        self.assertEqual(PartTestTemplate.generateTestKey('bob%35'),'bob35')
+        self.assertEqual(PartTestTemplate.generateTestKey('bo b%35'),'bob35')
+        self.assertEqual(PartTestTemplate.generateTestKey('BO B%35'),'bob35')
+        self.assertEqual(PartTestTemplate.generateTestKey('      %  '),'')
+        self.assertEqual(PartTestTemplate.generateTestKey(''),'')

--- a/test/test_part.py
+++ b/test/test_part.py
@@ -658,6 +658,10 @@ class PartTest(InvenTreeTestCase):
         ret = PartRelated.add_related(self.api, parts[2], parts[3])
         self.assertTrue(ret)
 
+        # Take the same part twice, should fail
+        with self.assertRaises(HTTPError):
+            ret = PartRelated.add_related(self.api, parts[3], parts[3])
+
 
 class PartBarcodeTest(InvenTreeTestCase):
     """Tests for Part barcode functionality"""
@@ -719,9 +723,9 @@ class PartTestTemplateTest(InvenTreeTestCase):
     def test_generateKey(self):
         """Tests for generating a key for a PartTestTemplate"""
 
-        self.assertEqual(PartTestTemplate.generateTestKey('bob'),'bob')
-        self.assertEqual(PartTestTemplate.generateTestKey('bob%35'),'bob35')
-        self.assertEqual(PartTestTemplate.generateTestKey('bo b%35'),'bob35')
-        self.assertEqual(PartTestTemplate.generateTestKey('BO B%35'),'bob35')
-        self.assertEqual(PartTestTemplate.generateTestKey('      %  '),'')
-        self.assertEqual(PartTestTemplate.generateTestKey(''),'')
+        self.assertEqual(PartTestTemplate.generateTestKey('bob'), 'bob')
+        self.assertEqual(PartTestTemplate.generateTestKey('bob%35'), 'bob35')
+        self.assertEqual(PartTestTemplate.generateTestKey('bo b%35'), 'bob35')
+        self.assertEqual(PartTestTemplate.generateTestKey('BO B%35'), 'bob35')
+        self.assertEqual(PartTestTemplate.generateTestKey('      %  '), '')
+        self.assertEqual(PartTestTemplate.generateTestKey(''), '')

--- a/test/test_part.py
+++ b/test/test_part.py
@@ -15,9 +15,9 @@ sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 
 from test_api import InvenTreeTestCase  # noqa: E402
 
-from inventree.build import Build
-from inventree.company import SupplierPart
-from inventree.stock import StockItem
+from inventree.build import Build  # noqa: E402
+from inventree.company import SupplierPart  # noqa: E402
+from inventree.stock import StockItem  # noqa: E402
 from inventree.part import Part, PartAttachment, PartCategory, PartCategoryParameterTemplate, Parameter, ParameterTemplate, PartTestTemplate, PartRelated, BomItem  # noqa: E402
 from inventree.part import InternalPrice  # noqa: E402
 
@@ -191,14 +191,13 @@ class PartTest(InvenTreeTestCase):
                 'getInternalPriceList': InternalPrice,
                 'getAttachments': PartAttachment,
             }
-            for fnc,res in functions.items():
-                A = getattr(p,fnc)()
+            for fnc, res in functions.items():
+                A = getattr(p, fnc)()
                 # Make sure a list is returned
-                self.assertIsInstance(A,list)
+                self.assertIsInstance(A, list)
                 for a in A:
                     # Make sure any result is of the right class
-                    self.assertIsInstance(a,res)
-
+                    self.assertIsInstance(a, res)
 
     def test_access_erors(self):
         """
@@ -579,7 +578,7 @@ class PartTest(InvenTreeTestCase):
         param = Parameter.create(self.api, data={'part': p.pk, 'template': parametertemplate.pk, 'data': 10})
 
         # Unit should be equal
-        self.assertEqual(param.getunits(),'kg A')
+        self.assertEqual(param.getunits(), 'kg A')
 
         # result should not be None
         self.assertIsNotNone(param)

--- a/test/test_part.py
+++ b/test/test_part.py
@@ -643,6 +643,21 @@ class PartTest(InvenTreeTestCase):
         self.assertEqual(metadata['foo'], 'rab')
         self.assertEqual(metadata['hello'], 'world')
 
+    def test_part_related(self):
+        """Test add related function"""
+
+        parts = Part.list(self.api)
+
+        # Take two parts, make them related
+        # Try with pk values
+        ret = PartRelated.add_related(self.api, parts[0].pk, parts[1].pk)
+        self.assertTrue(ret)
+
+        # Take two parts, make them related
+        # Try with Part object
+        ret = PartRelated.add_related(self.api, parts[2], parts[3])
+        self.assertTrue(ret)
+
 
 class PartBarcodeTest(InvenTreeTestCase):
     """Tests for Part barcode functionality"""


### PR DESCRIPTION
These tests cover functions not yet tested according to [Coveralls](https://coveralls.io/builds/54390705/source?filename=inventree%2Fpart.py)

While making tests, I realised that functions getunits() and getSupplierParts() for non-purchaseable parts needed modification.

Goal is to get 100% test coverage for the part.py file