### PR TITLE
Receive line items (Fix #82)

### DIFF
--- a/inventree/order.py
+++ b/inventree/order.py
@@ -111,7 +111,7 @@ class PurchaseOrder(
         }
 
         # Set the url
-        URL =  f"{self.URL}/{self.pk}/receive/"
+        URL = f"{self.URL}/{self.pk}/receive/"
 
         # Send data
         response = self._api.post(URL, data)

--- a/inventree/order.py
+++ b/inventree/order.py
@@ -111,7 +111,7 @@ class PurchaseOrder(
         }
 
         # Set the url
-        URL = self.URL + f"/{self.pk}/receive/"
+        URL =  f"{self.URL}/{self.pk}/receive/"
 
         # Send data
         response = self._api.post(URL, data)

--- a/inventree/order.py
+++ b/inventree/order.py
@@ -201,7 +201,7 @@ class PurchaseOrderLineItem(inventree.base.InventreeObject):
         }
 
         # Set the url
-        URL = self.getOrder().URL + f"/{self.getOrder().pk}/receive/"
+        URL = f"{self.getOrder().URL}/{self.getOrder().pk}/receive/"
 
         # Send data
         response = self._api.post(URL, data)

--- a/inventree/order.py
+++ b/inventree/order.py
@@ -184,9 +184,6 @@ class PurchaseOrderLineItem(inventree.base.InventreeObject):
             except:  # noqa:E722
                 location_id = int(location)
 
-        # Now check so that location is not None
-        assert location_id is not None, ValueError("No destination given.")
-
         # Prepare request data
         data = {
             'items': [

--- a/inventree/order.py
+++ b/inventree/order.py
@@ -3,6 +3,7 @@
 import inventree.base
 import inventree.part
 import inventree.company
+from inventree.stock import StockLocation
 
 
 class PurchaseOrder(
@@ -59,6 +60,69 @@ class PurchaseOrder(
         # Return
         return self._statusupdate(status='issue', **kwargs)
 
+    def receiveAll(self, location, status=10):
+        """
+        Receive all of the purchase order items, into the given location.
+
+        Note that the location may be overwritten if a destination is saved in the PO for the line item.
+
+        By default, the status is set to OK (Code 10).
+
+        To modify the defaults, use the arguments:
+            status: Status code
+                    10 OK
+                    50 ATTENTION
+                    55 DAMAGED
+                    60 DESTROYED
+                    65 REJECTED
+                    70 LOST
+                    75 QUARANTINED
+                    85 RETURNED
+        """
+
+        # Check if location is a StockLocation item or an integer
+        if isinstance(location, StockLocation):
+            location_id = location.pk
+        else:
+            location_id = int(location)
+
+        # Prepare request data
+        items = list()
+        for li in self.getLineItems():
+            quantity_to_receive = li.quantity - li.received
+            # Make sure quantity > 0
+            if quantity_to_receive > 0:
+                items.append(
+                    {
+                        'line_item': li.pk,
+                        'supplier_part': li.part,
+                        'quantity': quantity_to_receive,
+                        'status': status,
+                        'location': location_id,
+                    }
+                )
+
+        # If nothing is left, quit here
+        if len(items) < 1:
+            return None
+
+        data = {
+            'items': items,
+            'location': location_id
+        }
+
+        # Set the url
+        URL = self.URL + f"/{self.pk}/receive/"
+
+        # Send data
+        response = self._api.post(URL, data)
+
+        # Reload
+        self.reload()
+
+        # Return
+        return response
+
 
 class PurchaseOrderLineItem(inventree.base.InventreeObject):
     """ Class representing the PurchaseOrderLineItem database model """
@@ -82,6 +146,75 @@ class PurchaseOrderLineItem(inventree.base.InventreeObject):
         Return the PurchaseOrder to which this PurchaseOrderLineItem belongs
         """
         return PurchaseOrder(self._api, self.order)
+
+    def receive(self, quantity=None, status=10, location=None, batch_code='', serial_numbers=''):
+        """
+        Mark this line item as received.
+
+        By default, receives all remaining items in the order, and puts them in the destination defined in the PO.
+        The status is set to OK (Code 10).
+
+        To modify the defaults, use the arguments:
+            quantity: Number of units to receive. If None, will calculate the quantity not yet received and receive these.
+            status: Status code
+                    10 OK
+                    50 ATTENTION
+                    55 DAMAGED
+                    60 DESTROYED
+                    65 REJECTED
+                    70 LOST
+                    75 QUARANTINED
+                    85 RETURNED
+            location: Location ID, or a StockLocation item
+
+        If given, the following arguments are also sent as parameters:
+            batch_code
+            serial_numbers
+        """
+
+        if quantity is None:
+            # Substract number of already received lines from the order quantity
+            quantity = self.quantity - self.received
+
+        if location is None:
+            location_id = self.destination
+        else:
+            # Check if location is a StockLocation item or an integer
+            if isinstance(location, StockLocation):
+                location_id = location.pk
+            else:
+                location_id = int(location)
+
+        # Now check so that location is not None
+        assert location_id is not None, ValueError("No destination given.")
+
+        # Prepare request data
+        data = {
+            'items': [
+                {
+                    'line_item': self.pk,
+                    'supplier_part': self.part,
+                    'quantity': quantity,
+                    'status': status,
+                    'location': location_id,
+                    'batch_code': batch_code,
+                    'serial_numbers': serial_numbers
+                }
+            ],
+            'location': location_id
+        }
+
+        # Set the url
+        URL = self.getOrder().URL + f"/{self.getOrder().pk}/receive/"
+
+        # Send data
+        response = self._api.post(URL, data)
+
+        # Reload
+        self.reload()
+
+        # Return
+        return response
 
 
 class PurchaseOrderExtraLineItem(inventree.base.InventreeObject):

--- a/inventree/order.py
+++ b/inventree/order.py
@@ -3,7 +3,6 @@
 import inventree.base
 import inventree.part
 import inventree.company
-from inventree.stock import StockLocation
 
 
 class PurchaseOrder(
@@ -80,10 +79,10 @@ class PurchaseOrder(
                     85 RETURNED
         """
 
-        # Check if location is a StockLocation item or an integer
-        if isinstance(location, StockLocation):
+        # Check if location is a model - or try to get an integer
+        try:
             location_id = location.pk
-        else:
+        except:  # noqa:E722
             location_id = int(location)
 
         # Prepare request data
@@ -179,10 +178,10 @@ class PurchaseOrderLineItem(inventree.base.InventreeObject):
         if location is None:
             location_id = self.destination
         else:
-            # Check if location is a StockLocation item or an integer
-            if isinstance(location, StockLocation):
+            # Check if location is a model - or try to get an integer
+            try:
                 location_id = location.pk
-            else:
+            except:  # noqa:E722
                 location_id = int(location)
 
         # Now check so that location is not None

--- a/test/test_order.py
+++ b/test/test_order.py
@@ -261,6 +261,9 @@ class POTest(InvenTreeTestCase):
         self.assertEqual(new_stock_item.quantity, 5)
         self.assertEqual(new_stock_item.status, 50)
 
+        # Receive the rest of this item, with defaults
+        po_line_0.receive()
+
         # Receive all line items
         # Use the ID of the location here
         result = po.receiveAll(location=use_location.pk)

--- a/test/test_order.py
+++ b/test/test_order.py
@@ -183,8 +183,108 @@ class POTest(InvenTreeTestCase):
         self.assertEqual(po.status, 40)
         self.assertEqual(po.status_text, "Cancelled")
 
+    def test_order_complete_with_receive(self):
+        """Test that we can complete an order via the API, after receiving
+        items via API"""
+
+        n = len(order.PurchaseOrder.list(self.api)) + 1
+        ref = f"PO-{n}"
+
+        # First, let's create a new PurchaseOrder
+        po = order.PurchaseOrder.create(self.api, data={
+            'supplier': 1,
+            'reference': ref,
+            'description': 'A purchase order with items to be received',
+        })
+
+        # Add some line items
+        for p in company.SupplierPart.list(self.api, supplier=1, limit=5):
+
+            po.addLineItem(
+                part=p.pk,
+                quantity=10,
+            )
+
+        # Check that lines have actually been added
+        lines = po.getLineItems()
+        self.assertTrue(len(lines) > 0)
+
+        # Initial status code is "PENDING"
+        self.assertEqual(po.status, 10)
+        self.assertEqual(po.status_text, "Pending")
+
+        # Receive lines too early, assert error
+        with self.assertRaises(HTTPError):
+            po.receiveAll(location=1)
+
+        # Issue the order
+        po.issue()
+        po.reload()
+
+        self.assertEqual(po.status, 20)
+        self.assertEqual(po.status_text, "Placed")
+
+        # Try to complete the order (should fail, as lines have not been received)
+        with self.assertRaises(HTTPError):
+            po.complete()
+    
+        po.reload()
+
+        # Check that order status has *not* changed
+        self.assertEqual(po.status, 20)
+
+        # Get first location
+        use_location = stock.StockLocation.list(api, limit=1)[0]
+
+        # Prepare one line item for special treatment
+        po_line_0 = po.getLineItems()[0]
+
+        # Get list of items currently in stock, for comparison later
+        stock_items_before = stock.StockItem.list(self.api, supplier_part=po_line_0.part, location=use_location.pk)
+        pks_before = [x.pk for x in stock_items_before]
+
+        # Now, receive some of one of the line item with status ATTENTION
+        po_line_0.receive(location=1, status=50, quantity=5)
+
+        # Get new list of stock items
+        stock_items_after = stock.StockItem.list(self.api, supplier_part=po_line_0.part, location=use_location.pk)
+        pks_after = [x.pk for x in stock_items_after]
+
+        # make sure a stock item has been added
+        self.assertEqual(len(pks_after), len(pks_before)+1)
+
+        # Get the newly added PK and stock item
+        newpk = list(set(pks_after) - set(pks_before))[0]
+        new_stock_item = stock.StockItem(api, pk=newpk)
+
+        # Check the last stock item for the expected quantity and status
+        self.assertEqual(new_stock_item.quantity, 5)
+        self.assertEqual(new_stock_item.status, 50)
+
+        # Receive all line items
+        # Use the ID of the location here
+        result = po.receiveAll(location=use_location.pk)
+
+        # Check the result returned
+        self.assertIsInstance(result, dict)
+        self.assertIn('items', result)
+        self.assertIn('location', result)
+        self.assertEqual(len(result['items']), len(po.getLineItems()))
+
+        # Receive all line items again - make sure answer is None
+        # use the StockLocation item here
+        result = po.receiveAll(location=use_location)
+        self.assertIsNone(result)
+
+        # Complete the order, do not accept any incomplete lines
+        po.complete(accept_incomplete=False)
+        po.reload()
+
+        # Check that the order is now complete
+        self.assertEqual(po.status, 30)
+
     def test_order_complete(self):
-        """Test that we can complete an order via the API"""
+        """Test that we can complete an order via the API, with un-finished items remaining"""
 
         n = len(order.PurchaseOrder.list(self.api)) + 1
         ref = f"PO-{n}"

--- a/test/test_order.py
+++ b/test/test_order.py
@@ -272,7 +272,8 @@ class POTest(InvenTreeTestCase):
         self.assertIsInstance(result, dict)
         self.assertIn('items', result)
         self.assertIn('location', result)
-        self.assertEqual(len(result['items']), len(po.getLineItems()))
+        # Check that all except one line were marked
+        self.assertEqual(len(result['items']), len(po.getLineItems())-1)
 
         # Receive all line items again - make sure answer is None
         # use the StockLocation item here

--- a/test/test_order.py
+++ b/test/test_order.py
@@ -234,7 +234,7 @@ class POTest(InvenTreeTestCase):
         self.assertEqual(po.status, 20)
 
         # Get first location
-        use_location = stock.StockLocation.list(api, limit=1)[0]
+        use_location = stock.StockLocation.list(self.api, limit=1)[0]
 
         # Prepare one line item for special treatment
         po_line_0 = po.getLineItems()[0]
@@ -244,18 +244,18 @@ class POTest(InvenTreeTestCase):
         pks_before = [x.pk for x in stock_items_before]
 
         # Now, receive some of one of the line item with status ATTENTION
-        po_line_0.receive(location=1, status=50, quantity=5)
+        po_line_0.receive(location=use_location.pk, status=50, quantity=5)
 
         # Get new list of stock items
         stock_items_after = stock.StockItem.list(self.api, supplier_part=po_line_0.part, location=use_location.pk)
         pks_after = [x.pk for x in stock_items_after]
 
         # make sure a stock item has been added
-        self.assertEqual(len(pks_after), len(pks_before)+1)
+        self.assertEqual(len(pks_after), len(pks_before) + 1)
 
         # Get the newly added PK and stock item
         newpk = list(set(pks_after) - set(pks_before))[0]
-        new_stock_item = stock.StockItem(api, pk=newpk)
+        new_stock_item = stock.StockItem(self.api, pk=newpk)
 
         # Check the last stock item for the expected quantity and status
         self.assertEqual(new_stock_item.quantity, 5)

--- a/test/test_order.py
+++ b/test/test_order.py
@@ -197,12 +197,15 @@ class POTest(InvenTreeTestCase):
             'description': 'A purchase order with items to be received',
         })
 
+        # Get first location
+        use_location = stock.StockLocation.list(self.api, limit=1)[0]
+
         # Add some line items
         for p in company.SupplierPart.list(self.api, supplier=1, limit=5):
-
             po.addLineItem(
                 part=p.pk,
                 quantity=10,
+                destination=use_location.pk
             )
 
         # Check that lines have actually been added
@@ -233,9 +236,6 @@ class POTest(InvenTreeTestCase):
         # Check that order status has *not* changed
         self.assertEqual(po.status, 20)
 
-        # Get first location
-        use_location = stock.StockLocation.list(self.api, limit=1)[0]
-
         # Prepare one line item for special treatment
         po_line_0 = po.getLineItems()[0]
 
@@ -244,7 +244,7 @@ class POTest(InvenTreeTestCase):
         pks_before = [x.pk for x in stock_items_before]
 
         # Now, receive some of one of the line item with status ATTENTION
-        po_line_0.receive(location=use_location.pk, status=50, quantity=5)
+        po_line_0.receive(status=50, quantity=5)
 
         # Get new list of stock items
         stock_items_after = stock.StockItem.list(self.api, supplier_part=po_line_0.part, location=use_location.pk)

--- a/test/test_order.py
+++ b/test/test_order.py
@@ -273,7 +273,7 @@ class POTest(InvenTreeTestCase):
         self.assertIn('items', result)
         self.assertIn('location', result)
         # Check that all except one line were marked
-        self.assertEqual(len(result['items']), len(po.getLineItems())-1)
+        self.assertEqual(len(result['items']), len(po.getLineItems()) - 1)
 
         # Receive all line items again - make sure answer is None
         # use the StockLocation item here


### PR DESCRIPTION
This adds two methods, and tests, as described in #82 

For receiving a single line item of a PO:
`PurchaseOrderLineItem.receive(...`
with the ability to give details (quantity, status, batch codes, serial numbers, etc)

`PurchaseOrder.receiveAll(...`
The quick method, which can be run given only a location (limitation of the API, not the python binding), and sets all line items as received.
