### PR TITLE
Add keys(), __contains__ method to InventreeObject

### DIFF
--- a/inventree/base.py
+++ b/inventree/base.py
@@ -296,6 +296,12 @@ class InventreeObject(object):
         else:
             raise AttributeError(f"model.reload failed at '{self._url}': No API instance provided")
 
+    def keys(self):
+        return self._data.keys()
+
+    def __contains__(self, name):
+        return name in self._data
+
     def __getattr__(self, name):
 
         if name in self._data.keys():


### PR DESCRIPTION
Without these, calling code such as the following on `R` being any InventreeObject, will fail:

```
dict(R)
'pk' in R
R.keys()
```

with an error something like this:
```
  File "... inventree-python/inventree/base.py", line 310, in __getitem__
    raise KeyError(f"Key '{name}' does not exist in dataset")
KeyError: "Key '0' does not exist in dataset"
```

After adding these methods, the above results in something like this:
```
>>> dict(R)
{'pk': 12, 'name': 'Dimension', 'units': '', 'description': ''}
>>> R.keys()
dict_keys(['pk', 'name', 'units', 'description'])
>>> 'pk' in R
True
```