### PR TITLE
Add add_link function to Attachment class

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -30,7 +30,7 @@ Before the first test, run the following:
 invoke update-image
 ```
 
-The `invoke-test` command performs the following sequence of actions:
+The `invoke test` command performs the following sequence of actions:
 
 - Ensures the test InvenTree server is running (in a docker container)
 - Resets the test database to a known state

--- a/inventree/base.py
+++ b/inventree/base.py
@@ -379,6 +379,33 @@ class Attachment(BulkDeleteMixin, InventreeObject):
     REQUIRED_KWARGS = []
 
     @classmethod
+    def add_link(cls, api, link, comment="", **kwargs):
+        """
+        Add an external link attachment.
+
+        Args:
+            api: Authenticated InvenTree API instance
+            link: External link to attach
+            comment: Add comment to the attachment
+            kwargs: Additional kwargs to suppl
+        """
+
+        data = kwargs
+        data["comment"] = comment
+        data["link"] = link
+
+        for arg in cls.REQUIRED_KWARGS:
+            if arg not in kwargs:
+                raise ValueError(f"Required argument '{arg}' not supplied to upload method")
+
+        if response := api.post(cls.URL, data):
+            logger.info(f"Link attachment added to {cls.URL}")
+        else:
+            logger.error(f"Link attachment failed at {cls.URL}")
+
+        return response
+
+    @classmethod
     def upload(cls, api, attachment, comment='', **kwargs):
         """
         Upload a file attachment.

--- a/inventree/base.py
+++ b/inventree/base.py
@@ -7,7 +7,7 @@ from typing import Type
 
 from . import api as inventree_api
 
-INVENTREE_PYTHON_VERSION = "0.13.1"
+INVENTREE_PYTHON_VERSION = "0.13.2"
 
 
 logger = logging.getLogger('inventree')

--- a/inventree/build.py
+++ b/inventree/build.py
@@ -4,11 +4,19 @@ import inventree.base
 import inventree.report
 
 
+class BuildAttachment(inventree.base.Attachment):
+    """Class representing an attachment against a Build object"""
+
+    URL = 'build/attachment'
+    ATTACH_TO = 'build'
+
+
 class Build(
-    inventree.base.InventreeObject,
+    inventree.base.AttachmentMixin(BuildAttachment),
     inventree.base.StatusMixin,
     inventree.base.MetadataMixin,
     inventree.report.ReportPrintingMixin,
+    inventree.base.InventreeObject,
 ):
     """ Class representing the Build database model """
 
@@ -17,17 +25,6 @@ class Build(
     # Setup for Report mixin
     REPORTNAME = 'build'
     REPORTITEM = 'build'
-
-    def getAttachments(self):
-        return BuildAttachment.list(self._api, build=self.pk)
-
-    def uploadAttachment(self, attachment, comment=''):
-        return BuildAttachment.upload(
-            self._api,
-            attachment,
-            comment=comment,
-            build=self.pk
-        )
 
     def complete(
         self,
@@ -52,10 +49,3 @@ class Build(
     def finish(self, *args, **kwargs):
         """Alias for complete"""
         return self.complete(*args, **kwargs)
-
-
-class BuildAttachment(inventree.base.Attachment):
-    """Class representing an attachment against a Build object"""
-
-    URL = 'build/attachment'
-    REQUIRED_KWARGS = ['build']

--- a/inventree/company.py
+++ b/inventree/company.py
@@ -98,7 +98,19 @@ class SupplierPart(inventree.base.BarcodeMixin, inventree.base.BulkDeleteMixin, 
         return SupplierPriceBreak.list(self._api, part=self.pk)
 
 
-class ManufacturerPart(inventree.base.BulkDeleteMixin, inventree.base.MetadataMixin, inventree.base.InventreeObject):
+class ManufacturerPartAttachment(inventree.base.Attachment):
+    """Class representing an attachment against a ManufacturerPart object"""
+
+    URL = 'company/part/manufacturer/attachment'
+    ATTACH_TO = 'manufacturer_part'
+
+
+class ManufacturerPart(
+    inventree.base.AttachmentMixin(ManufacturerPartAttachment),
+    inventree.base.BulkDeleteMixin,
+    inventree.base.MetadataMixin,
+    inventree.base.InventreeObject,
+):
     """Class representing the ManufacturerPart database model
 
     - Implements the BulkDeleteMixin
@@ -113,19 +125,6 @@ class ManufacturerPart(inventree.base.BulkDeleteMixin, inventree.base.MetadataMi
 
         return ManufacturerPartParameter.list(self._api, manufacturer_part=self.pk, **kwargs)
 
-    def getAttachments(self, **kwargs):
-
-        return ManufacturerPartAttachment.list(self._api, manufacturer_part=self.pk, **kwargs)
-
-    def uploadAttachment(self, attachment, comment=''):
-
-        return ManufacturerPartAttachment.upload(
-            self._api,
-            attachment,
-            comment=comment,
-            manufacturer_part=self.pk,
-        )
-
 
 class ManufacturerPartParameter(inventree.base.BulkDeleteMixin, inventree.base.InventreeObject):
     """Class representing the ManufacturerPartParameter database model.
@@ -134,14 +133,6 @@ class ManufacturerPartParameter(inventree.base.BulkDeleteMixin, inventree.base.I
     """
 
     URL = 'company/part/manufacturer/parameter'
-
-
-class ManufacturerPartAttachment(inventree.base.Attachment):
-    """
-    Class representing the ManufacturerPartAttachment model
-    """
-
-    URL = 'company/part/manufacturer/attachment'
 
 
 class SupplierPriceBreak(inventree.base.InventreeObject):

--- a/inventree/part.py
+++ b/inventree/part.py
@@ -58,7 +58,21 @@ class PartCategory(inventree.base.MetadataMixin, inventree.base.InventreeObject)
         )
 
 
-class Part(inventree.base.BarcodeMixin, inventree.base.MetadataMixin, inventree.base.ImageMixin, inventree.label.LabelPrintingMixin, inventree.base.InventreeObject):
+class PartAttachment(inventree.base.Attachment):
+    """Class representing a file attachment for a Part"""
+
+    URL = 'part/attachment'
+    ATTACH_TO = 'part'
+
+
+class Part(
+    inventree.base.AttachmentMixin(PartAttachment),
+    inventree.base.BarcodeMixin,
+    inventree.base.MetadataMixin,
+    inventree.base.ImageMixin,
+    inventree.label.LabelPrintingMixin,
+    inventree.base.InventreeObject
+):
     """ Class representing the Part database model """
 
     URL = 'part'
@@ -124,25 +138,6 @@ class Part(inventree.base.BarcodeMixin, inventree.base.MetadataMixin, inventree.
 
         return InternalPrice.setInternalPrice(self._api, self.pk, quantity, price)
 
-    def getAttachments(self):
-        return PartAttachment.list(self._api, part=self.pk)
-
-    def uploadAttachment(self, attachment, comment=''):
-        """
-        Upload an attachment (file) against this Part.
-
-        Args:
-            attachment: Either a string (filename) or a file object
-            comment: Attachment comment
-        """
-
-        return PartAttachment.upload(
-            self._api,
-            attachment,
-            comment=comment,
-            part=self.pk
-        )
-
     def getRequirements(self):
         """
         Get required amounts from requirements API endpoint for this part
@@ -153,14 +148,6 @@ class Part(inventree.base.BarcodeMixin, inventree.base.MetadataMixin, inventree.
 
         # Get data
         return self._api.get(URL)
-
-
-class PartAttachment(inventree.base.Attachment):
-    """ Class representing a file attachment for a Part """
-
-    URL = 'part/attachment'
-
-    REQUIRED_KWARGS = ['part']
 
 
 class PartTestTemplate(inventree.base.MetadataMixin, inventree.base.InventreeObject):

--- a/inventree/part.py
+++ b/inventree/part.py
@@ -71,7 +71,7 @@ class Part(
     inventree.base.MetadataMixin,
     inventree.base.ImageMixin,
     inventree.label.LabelPrintingMixin,
-    inventree.base.InventreeObject
+    inventree.base.InventreeObject,
 ):
     """ Class representing the Part database model """
 

--- a/inventree/purchase_order.py
+++ b/inventree/purchase_order.py
@@ -8,11 +8,19 @@ import inventree.part
 import inventree.report
 
 
+class PurchaseOrderAttachment(inventree.base.Attachment):
+    """Class representing a file attachment for a PurchaseOrder"""
+
+    URL = 'order/po/attachment'
+    ATTACH_TO = 'order'
+
+
 class PurchaseOrder(
+    inventree.base.AttachmentMixin(PurchaseOrderAttachment),
     inventree.base.MetadataMixin,
-    inventree.base.InventreeObject,
     inventree.base.StatusMixin,
     inventree.report.ReportPrintingMixin,
+    inventree.base.InventreeObject,
 ):
     """ Class representing the PurchaseOrder database model """
 
@@ -58,17 +66,6 @@ class PurchaseOrder(
         kwargs['order'] = self.pk
 
         return PurchaseOrderExtraLineItem.create(self._api, data=kwargs)
-
-    def getAttachments(self):
-        return PurchaseOrderAttachment.list(self._api, order=self.pk)
-
-    def uploadAttachment(self, attachment, comment=''):
-        return PurchaseOrderAttachment.upload(
-            self._api,
-            attachment,
-            comment=comment,
-            order=self.pk,
-        )
 
     def issue(self, **kwargs):
         """
@@ -248,10 +245,3 @@ class PurchaseOrderExtraLineItem(
         Return the PurchaseOrder to which this PurchaseOrderLineItem belongs
         """
         return PurchaseOrder(self._api, self.order)
-
-
-class PurchaseOrderAttachment(inventree.base.Attachment):
-    """Class representing a file attachment for a PurchaseOrder"""
-
-    URL = 'order/po/attachment'
-    REQUIRED_KWARGS = ['order']

--- a/inventree/return_order.py
+++ b/inventree/return_order.py
@@ -9,11 +9,20 @@ import inventree.report
 import inventree.stock
 
 
+class ReturnOrderAttachment(inventree.base.InventreeObject):
+    """Class representing the ReturnOrderAttachment model"""
+
+    URL = 'order/ro/attachment'
+    ATTACH_TO = 'order'
+    REQUIRED_API_VERSION = 104
+
+
 class ReturnOrder(
+    inventree.base.AttachmentMixin(ReturnOrderAttachment),
     inventree.base.MetadataMixin,
-    inventree.base.InventreeObject,
     inventree.base.StatusMixin,
     inventree.report.ReportPrintingMixin,
+    inventree.base.InventreeObject,
 ):
     """Class representing the ReturnOrder database model"""
 
@@ -53,19 +62,6 @@ class ReturnOrder(
         kwargs['order'] = self.pk
         return ReturnOrderExtraLineItem.create(self._api, data=kwargs)
 
-    def getAttachments(self):
-        """Return a list of attachments associated with this order"""
-        return ReturnOrderAttachment.list(self._api, order=self.pk)
-
-    def uploadAttachment(self, attachment, comment=''):
-        """Upload a file attachment against this order"""
-        return ReturnOrderAttachment.upload(
-            self._api,
-            attachment,
-            comment=comment,
-            order=self.pk
-        )
-
     def issue(self, **kwargs):
         """Issue (send) this order"""
         return self._statusupdate(status='issue', **kwargs)
@@ -103,11 +99,3 @@ class ReturnOrderExtraLineItem(inventree.base.InventreeObject):
     def getOrder(self):
         """Return the ReturnOrder to which this line item belongs"""
         return ReturnOrder(self._api, self.order)
-
-
-class ReturnOrderAttachment(inventree.base.InventreeObject):
-    """Class representing the ReturnOrderAttachment model"""
-
-    URL = 'order/ro/attachment'
-    REQUIRED_KWARGS = ['order']
-    REQUIRED_API_VERSION = 104

--- a/inventree/sales_order.py
+++ b/inventree/sales_order.py
@@ -8,11 +8,19 @@ import inventree.part
 import inventree.report
 
 
+class SalesOrderAttachment(inventree.base.Attachment):
+    """Class representing a file attachment for a SalesOrder"""
+
+    URL = 'order/so/attachment'
+    ATTACH_TO = 'order'
+
+
 class SalesOrder(
+    inventree.base.AttachmentMixin(SalesOrderAttachment),
     inventree.base.MetadataMixin,
-    inventree.base.InventreeObject,
     inventree.base.StatusMixin,
     inventree.report.ReportPrintingMixin,
+    inventree.base.InventreeObject,
 ):
     """ Class representing the SalesOrder database model """
 
@@ -58,17 +66,6 @@ class SalesOrder(
         kwargs['order'] = self.pk
 
         return SalesOrderExtraLineItem.create(self._api, data=kwargs)
-
-    def getAttachments(self):
-        return SalesOrderAttachment.list(self._api, order=self.pk)
-
-    def uploadAttachment(self, attachment, comment=''):
-        return SalesOrderAttachment.upload(
-            self._api,
-            attachment,
-            comment=comment,
-            order=self.pk,
-        )
 
     def getShipments(self, **kwargs):
         """ Return the shipments associated with this order """
@@ -189,14 +186,6 @@ class SalesOrderExtraLineItem(
         Return the SalesOrder to which this SalesOrderLineItem belongs
         """
         return SalesOrder(self._api, self.order)
-
-
-class SalesOrderAttachment(inventree.base.Attachment):
-    """Class representing a file attachment for a SalesOrder"""
-
-    URL = 'order/so/attachment'
-
-    REQUIRED_KWARGS = ['order']
 
 
 class SalesOrderShipment(

--- a/inventree/stock.py
+++ b/inventree/stock.py
@@ -51,7 +51,21 @@ class StockLocation(
         return StockLocation.list(self._api, parent=self.pk, **kwargs)
 
 
-class StockItem(inventree.base.BarcodeMixin, inventree.base.BulkDeleteMixin, inventree.base.MetadataMixin, inventree.label.LabelPrintingMixin, inventree.base.InventreeObject):
+class StockItemAttachment(inventree.base.Attachment):
+    """Class representing a file attachment for a StockItem"""
+
+    URL = 'stock/attachment'
+    ATTACH_TO = 'stock_item'
+
+
+class StockItem(
+    inventree.base.AttachmentMixin(StockItemAttachment),
+    inventree.base.BarcodeMixin,
+    inventree.base.BulkDeleteMixin,
+    inventree.base.MetadataMixin,
+    inventree.label.LabelPrintingMixin,
+    inventree.base.InventreeObject
+):
     """Class representing the StockItem database model."""
 
     URL = 'stock'
@@ -312,34 +326,6 @@ class StockItem(inventree.base.BarcodeMixin, inventree.base.BulkDeleteMixin, inv
         """ Upload a test result against this StockItem """
 
         return StockItemTestResult.upload_result(self._api, self.pk, test_name, test_result, **kwargs)
-
-    def getAttachments(self):
-        """ Return all file attachments for this StockItem """
-
-        return StockItemAttachment.list(
-            self._api,
-            stock_item=self.pk
-        )
-
-    def uploadAttachment(self, attachment, comment=''):
-        """
-        Upload an attachment against this StockItem
-        """
-
-        return StockItemAttachment.upload(
-            self._api,
-            attachment,
-            comment=comment,
-            stock_item=self.pk
-        )
-
-
-class StockItemAttachment(inventree.base.Attachment):
-    """ Class representing a file attachment for a StockItem """
-
-    URL = 'stock/attachment'
-
-    REQUIRED_KWARGS = ['stock_item']
 
 
 class StockItemTracking(inventree.base.InventreeObject):

--- a/inventree/stock.py
+++ b/inventree/stock.py
@@ -16,7 +16,7 @@ class StockLocation(
     inventree.base.MetadataMixin,
     inventree.label.LabelPrintingMixin,
     inventree.report.ReportPrintingMixin,
-    inventree.base.InventreeObject
+    inventree.base.InventreeObject,
 ):
     """ Class representing the StockLocation database model """
 
@@ -64,7 +64,7 @@ class StockItem(
     inventree.base.BulkDeleteMixin,
     inventree.base.MetadataMixin,
     inventree.label.LabelPrintingMixin,
-    inventree.base.InventreeObject
+    inventree.base.InventreeObject,
 ):
     """Class representing the StockItem database model."""
 
@@ -338,7 +338,7 @@ class StockItemTestResult(
     inventree.base.BulkDeleteMixin,
     inventree.base.MetadataMixin,
     inventree.report.ReportPrintingMixin,
-    inventree.base.InventreeObject
+    inventree.base.InventreeObject,
 ):
     """Class representing a StockItemTestResult object"""
 

--- a/test/test_part.py
+++ b/test/test_part.py
@@ -502,6 +502,33 @@ class PartTest(InvenTreeTestCase):
             # Attempt to download the file again, but without overwrite option
             attachment.download(dst)
 
+    def test_part_link_attachment(self):
+        """
+        Check that we can add an external link attachment to the part
+        """
+
+        test_link = "https://inventree.org/"
+        test_comment = "inventree.org"
+
+        # Test that an external link attachment without the required 'part' parameter fails
+        with self.assertRaises(ValueError):
+            PartAttachment.add_link(self.api, link=test_link)
+
+        # Add valid external link attachment
+        response = PartAttachment.add_link(
+            self.api,
+            link=test_link,
+            comment=test_comment,
+            part=1
+        )
+        self.assertIsNotNone(response)
+
+        # Check that the attachment has been created
+        attachment = PartAttachment(self.api, pk=response["pk"])
+        self.assertTrue(attachment.is_valid())
+        self.assertEqual(attachment.link, test_link)
+        self.assertEqual(attachment.comment, test_comment)
+
     def test_set_price(self):
         """
         Tests that an internal price can be set for a part

--- a/test/test_part.py
+++ b/test/test_part.py
@@ -515,12 +515,8 @@ class PartTest(InvenTreeTestCase):
             PartAttachment.add_link(self.api, link=test_link)
 
         # Add valid external link attachment
-        response = PartAttachment.add_link(
-            self.api,
-            link=test_link,
-            comment=test_comment,
-            part=1
-        )
+        part = Part(self.api, pk=1)
+        response = part.addLinkAttachment(test_link, comment=test_comment)
         self.assertIsNotNone(response)
 
         # Check that the attachment has been created


### PR DESCRIPTION
This adds an `add_link` class method to the `Attachment` class, to make it possible to add external link attachments via the python api.

Should I also add a bunch of `addLinkAttachment` functions to `Part`, `Company`, etc. (similar to the `uploadAttachment` methods)?