### PR TITLE
Fix getting test key

### DIFF
--- a/inventree/part.py
+++ b/inventree/part.py
@@ -169,10 +169,15 @@ class PartTestTemplate(inventree.base.MetadataMixin, inventree.base.InventreeObj
 
     def getTestKey(self):
         """Return the 'key' for this test.
-        
+
         Note that after API v169, the 'key' parameter is also directly accessible
         """
-        return PartTestTemplate.generateTestKey(self.test_name)
+
+        # Try to return the key - fall back to generateTestKey
+        try:
+            return self.key
+        except AttributeError:
+            return self.generateTestKey(self.test_name)
 
 
 class BomItem(

--- a/inventree/stock.py
+++ b/inventree/stock.py
@@ -341,7 +341,7 @@ class StockItemTestResult(
     inventree.base.InventreeObject,
 ):
     """Class representing a StockItemTestResult object.
-    
+
     Note: From API version 169 and onwards, the StockItemTestResult object
     must reference a PartTestTemplate object, rather than a test name.
 
@@ -355,8 +355,15 @@ class StockItemTestResult(
     REPORTNAME = 'test'
     REPORTITEM = 'item'
 
+    def getTestTemplate(self):
+        '''Return the PartTestTemplate item for this StockItemTestResult'''
+
+        return inventree.part.PartTestTemplate(self._api, self.template)
+
     def getTestKey(self):
-        return inventree.part.PartTestTemplate.generateTestKey(self.test)
+
+        # Get the test key from the PartTestTemplate
+        return self.getTestTemplate().getTestKey()
 
     @classmethod
     def upload_result(cls, api, stock_item, test, result, **kwargs):


### PR DESCRIPTION
From StockItemTestResult, go via PartTestTemplate. Try to use defined key first.

(Previously, getting 'self.test' in StockItemTestResult would fail)