### PR TITLE
New printing api

### DIFF
--- a/inventree/base.py
+++ b/inventree/base.py
@@ -20,7 +20,8 @@ class InventreeObject(object):
     URL = ""
 
     # Minimum server version for the particular model type
-    REQUIRED_API_VERSION = None
+    MIN_API_VERSION = None
+    MAX_API_VERSION = None
 
     def __str__(self):
         """
@@ -75,9 +76,12 @@ class InventreeObject(object):
             NotSupportedError if the server API version is too 'old'
         """
 
-        if cls.REQUIRED_API_VERSION is not None:
-            if cls.REQUIRED_API_VERSION > api.api_version:
-                raise NotImplementedError(f"Server API Version ({api.api_version}) is too old for the '{cls.__name__}' class, which requires API version {cls.REQUIRED_API_VERSION}")
+        if cls.MIN_API_VERSION and cls.MIN_API_VERSION > api.api_version:
+            raise NotImplementedError(f"Server API Version ({api.api_version}) is too old for the '{cls.__name__}' class, which requires API version >= {cls.MIN_API_VERSION}")
+
+        if cls.MAX_API_VERSION and cls.MAX_API_VERSION < api.api_version:
+            raise NotImplementedError(f"Server API Version ({api.api_version}) is too new for the '{cls.__name__}' class, which requires API version <= {cls.MAX_API_VERSION}")
+
 
     @classmethod
     def options(cls, api):

--- a/inventree/base.py
+++ b/inventree/base.py
@@ -82,7 +82,6 @@ class InventreeObject(object):
         if cls.MAX_API_VERSION and cls.MAX_API_VERSION < api.api_version:
             raise NotImplementedError(f"Server API Version ({api.api_version}) is too new for the '{cls.__name__}' class, which requires API version <= {cls.MAX_API_VERSION}")
 
-
     @classmethod
     def options(cls, api):
         """Perform an OPTIONS request for this model, to determine model information.

--- a/inventree/base.py
+++ b/inventree/base.py
@@ -23,6 +23,8 @@ class InventreeObject(object):
     MIN_API_VERSION = None
     MAX_API_VERSION = None
 
+    MODEL_TYPE = None
+
     def __str__(self):
         """
         Simple human-readable printing.
@@ -67,6 +69,11 @@ class InventreeObject(object):
         # If the data are not populated, fetch from server
         if len(self._data) == 0:
             self.reload()
+
+    @classmethod
+    def getModelType(cls):
+        """Return the model type for this label printing class."""
+        return cls.MODEL_TYPE
 
     @classmethod
     def checkApiVersion(cls, api):

--- a/inventree/build.py
+++ b/inventree/build.py
@@ -21,6 +21,7 @@ class Build(
     """ Class representing the Build database model """
 
     URL = 'build'
+    MODEL_TYPE = 'build'
 
     # Setup for Report mixin
     REPORTNAME = 'build'

--- a/inventree/company.py
+++ b/inventree/company.py
@@ -12,14 +12,14 @@ class Contact(inventree.base.InventreeObject):
     """Class representing the Contact model"""
 
     URL = 'company/contact/'
-    REQUIRED_API_VERSION = 104
+    MIN_API_VERSION = 104
 
 
 class Address(inventree.base.InventreeObject):
     """Class representing the Address model"""
 
     URL = 'company/address/'
-    REQUIRED_API_VERSION = 126
+    MIN_API_VERSION = 126
 
 
 class Company(inventree.base.ImageMixin, inventree.base.MetadataMixin, inventree.base.InventreeObject):

--- a/inventree/label.py
+++ b/inventree/label.py
@@ -17,13 +17,18 @@ class LabelPrintingMixin:
 
     Classes which implement this mixin should define the following attributes:
 
-    LABELNAME: The name of the label type (e.g. 'part', 'stock', 'location')
-    LABELITEM: The name of the label item (e.g. 'parts', 'items', 'locations')
+    Legacy API: < 197
+        - LABELNAME: The name of the label type (e.g. 'part', 'stock', 'location')
+        - LABELITEM: The name of the label item (e.g. 'parts', 'items', 'locations')
+    
+    Modern API: >= 197
+        - MODEL_TYPE: The model type for the label printing class (e.g. 'part', 'stockitem', 'location')
     """
 
     LABELNAME = ''
     LABELITEM = ''
 
+    # Each class should specify the associated 'model_type' attribite - e.g. 'stockitem'
     MODEL_TYPE = None
 
     @classmethod

--- a/inventree/label.py
+++ b/inventree/label.py
@@ -234,21 +234,30 @@ class LabelFunctions(inventree.base.MetadataMixin, inventree.base.InventreeObjec
 
 
 class LabelLocation(LabelFunctions):
-    """ Class representing the Label/Location database model """
+    """Class representing the Label/Location database model.
+    
+    Note: This class will be deprecated at some point in the future.
+    """
 
     URL = 'label/location'
     MAX_API_VERSION = MODERN_LABEL_PRINTING_API - 1
 
 
 class LabelPart(LabelFunctions):
-    """ Class representing the Label/Part database model """
+    """Class representing the Label/Part database model.
+    
+    Note: This class will be deprecated at some point in the future.
+    """
 
     URL = 'label/part'
     MAX_API_VERSION = MODERN_LABEL_PRINTING_API - 1
 
 
 class LabelStock(LabelFunctions):
-    """ Class representing the Label/stock database model """
+    """Class representing the Label/stock database model.
+    
+    Note: This class will be deprecated at some point in the future.
+    """
 
     URL = 'label/stock'
     MAX_API_VERSION = MODERN_LABEL_PRINTING_API - 1

--- a/inventree/label.py
+++ b/inventree/label.py
@@ -268,3 +268,8 @@ class LabelTemplate(LabelFunctions):
 
     URL = 'label/template'
     MIN_API_VERSION = MODERN_LABEL_PRINTING_API
+
+    def __str__(self):
+        """String representation of the LabelTemplate instance."""
+
+        return f"LabelTemplate <{self.pk}>: '{self.name}' - ({self.model_type})"

--- a/inventree/label.py
+++ b/inventree/label.py
@@ -28,14 +28,6 @@ class LabelPrintingMixin:
     LABELNAME = ''
     LABELITEM = ''
 
-    # Each class should specify the associated 'model_type' attribite - e.g. 'stockitem'
-    MODEL_TYPE = None
-
-    @classmethod
-    def getModelType(cls):
-        """Return the model type for this label printing class."""
-        return cls.MODEL_TYPE or cls.LABELNAME
-
     def getTemplateId(self, template):
         """Return the ID (pk) from the supplied template."""
 
@@ -45,7 +37,7 @@ class LabelPrintingMixin:
         if hasattr(template, 'pk'):
             return int(template.pk)
         
-        raise ValueError(f"Provided template is not a valid type: {type(template)}")
+        raise ValueError(f"Provided label template is not a valid type: {type(template)}")
 
     def saveOutput(self, output, filename):
         """Save the output from a label printing job to the specified file path."""
@@ -161,8 +153,6 @@ class LabelPrintingMixin:
         if self._api.api_version < MODERN_LABEL_PRINTING_API:
             logger.error("Legacy label printing API is not supported")
             return []
-
-        print("getting templates for:", self.getModelType())
 
         return LabelTemplate.list(
             self._api,

--- a/inventree/label.py
+++ b/inventree/label.py
@@ -48,7 +48,7 @@ class LabelPrintingMixin:
         if os.path.exists(filename) and os.path.isdir(filename):
             filename = os.path.join(
                 filename,
-                f'Label_{self.getModelType()}_{label}_{self.pk}.pdf'
+                f'Label_{self.getModelType()}_{self.pk}.pdf'
             )
         
         return self._api.downloadFile(url=output, destination=filename)
@@ -158,6 +158,7 @@ class LabelPrintingMixin:
             model_type=self.getModelType(),
             **kwargs
         )
+
 
 class LabelFunctions(inventree.base.MetadataMixin, inventree.base.InventreeObject):
     """Base class for label functions."""

--- a/inventree/part.py
+++ b/inventree/part.py
@@ -81,6 +81,8 @@ class Part(
     LABELNAME = 'part'
     LABELITEM = 'parts'
 
+    MODEL_TYPE = 'part'
+
     def getCategory(self):
         """ Return the part category associated with this part """
         return PartCategory(self._api, self.category)

--- a/inventree/plugin.py
+++ b/inventree/plugin.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+
+import logging
+
+import inventree.base
+
+class InvenTreePlugin:
+    """Represents a PluginConfig instance on the InvenTree server."""
+
+    URL = 'plugin'

--- a/inventree/plugin.py
+++ b/inventree/plugin.py
@@ -4,7 +4,7 @@ import logging
 
 import inventree.base
 
-class InvenTreePlugin:
+class InvenTreePlugin(inventree.base.MetadataMixin, inventree.base.InventreeObject):
     """Represents a PluginConfig instance on the InvenTree server."""
 
-    URL = 'plugin'
+    URL = 'plugins'

--- a/inventree/plugin.py
+++ b/inventree/plugin.py
@@ -1,10 +1,16 @@
 # -*- coding: utf-8 -*-
 
-import logging
-
 import inventree.base
+
 
 class InvenTreePlugin(inventree.base.MetadataMixin, inventree.base.InventreeObject):
     """Represents a PluginConfig instance on the InvenTree server."""
 
     URL = 'plugins'
+
+    def setActive(self, active: bool):
+        """Activate or deactivate this plugin."""
+
+        url = f'plugins/{self.pk}/activate/'
+
+        self._api.post(url, data={'active': active})

--- a/inventree/project_code.py
+++ b/inventree/project_code.py
@@ -10,4 +10,4 @@ class ProjectCode(inventree.base.InventreeObject):
     """Class representing the 'ProjectCode' database model"""
 
     URL = 'project-code/'
-    REQUIRED_API_VERSION = 109
+    MIN_API_VERSION = 109

--- a/inventree/purchase_order.py
+++ b/inventree/purchase_order.py
@@ -25,6 +25,7 @@ class PurchaseOrder(
     """ Class representing the PurchaseOrder database model """
 
     URL = 'order/po'
+    MODEL_TYPE = 'purchaseorder'
 
     # Setup for Report mixin
     REPORTNAME = 'po'

--- a/inventree/report.py
+++ b/inventree/report.py
@@ -63,7 +63,7 @@ class ReportFunctions(inventree.base.MetadataMixin, inventree.base.InventreeObje
         """
 
         # POST endpoints for creating new reports were added in API version 156
-        cls.REQUIRED_API_VERSION = 156
+        cls.MIN_API_VERSION = 156
 
         try:
             # If template is already a readable object, don't convert it
@@ -90,7 +90,7 @@ class ReportFunctions(inventree.base.MetadataMixin, inventree.base.InventreeObje
         """
 
         # PUT/PATCH endpoints for updating data were available before POST endpoints
-        self.REQUIRED_API_VERSION = None
+        self.MIN_API_VERSION = None
 
         if template is not None:
             try:
@@ -159,7 +159,7 @@ class ReportStockLocation(ReportFunctions):
 
     # The Stock location report was added when API version was 127, but the API version was not incremented at the same time
     # The closest API version which has the SLR report is 128
-    REQUIRED_API_VERSION = 128
+    MIN_API_VERSION = 128
     URL = 'report/slr'
 
 

--- a/inventree/report.py
+++ b/inventree/report.py
@@ -7,6 +7,7 @@ import inventree.base
 # Ref: https://github.com/inventree/InvenTree/pull/7074
 MODERN_LABEL_PRINTING_API = 197
 
+
 class ReportPrintingMixin:
     """Mixin class for report printing.
 
@@ -49,7 +50,7 @@ class ReportPrintingMixin:
         if self._api.api_version < MODERN_LABEL_PRINTING_API:
             return self.printReportLegacy(report, destination, *args, **kwargs)
 
-        print_url = '/report/print/'        
+        print_url = '/report/print/'
         template_id = self.getTemplateId(report)
 
         response = self._api.post(
@@ -89,6 +90,7 @@ class ReportPrintingMixin:
         """Return a list of report templates which match this model class."""
 
         return ReportTemplate.list(self._api, model_type=self.MODEL_TYPE, **kwargs)
+
 
 class ReportFunctions(inventree.base.MetadataMixin, inventree.base.InventreeObject):
     """Base class for report functions"""
@@ -164,7 +166,6 @@ class ReportFunctions(inventree.base.MetadataMixin, inventree.base.InventreeObje
         return self._api.downloadFile(url=self._data['template'], destination=destination, overwrite=overwrite)
 
 
-
 class ReportTemplate(ReportFunctions):
     """Class representing the ReportTemplatel model."""
 
@@ -177,6 +178,7 @@ class ReportBoM(ReportFunctions):
 
     URL = 'report/bom'
     MAX_API_VERSION = MODERN_LABEL_PRINTING_API
+
 
 class ReportBuild(ReportFunctions):
     """Class representing ReportBuild"""

--- a/inventree/report.py
+++ b/inventree/report.py
@@ -3,26 +3,38 @@
 import inventree.base
 
 
+# The InvenTree API endpoint changed considerably @ version 197
+# Ref: https://github.com/inventree/InvenTree/pull/7074
+MODERN_LABEL_PRINTING_API = 197
+
 class ReportPrintingMixin:
     """Mixin class for report printing.
 
     Classes which implement this mixin should define the following attributes:
 
-    REPORTNAME: The name of the report type, as given in the API (e.g. 'bom', 'build', 'po')
-    See https://demo.inventree.org/api-doc/#tag/report
-    REPORTITEM: The name of items send to the report print endpoint.
-    This is the name of the array of items expected.
-
-    Example:
-    https://demo.inventree.org/api/report/test/?item[]=205
-        -> REPORTNAME = test
-        -> REPORTITEM = item
+    Legacy API:
+        - REPORTNAME: The name of the report type, as given in the API (e.g. 'bom', 'build', 'po')
+        - REPORTITEM: The name of items send to the report print endpoint.
+        
+    Modern API: >= 197
+        - MODEL_TYPE: The model type of the report (e.g. 'purchaseorder', 'stocklocation')
     """
 
     REPORTNAME = ''
     REPORTITEM = ''
 
-    def printreport(self, report, destination, *args, **kwargs):
+    def getTemplateId(self, template):
+        """Return the ID (pk) from the supplied template."""
+
+        if type(template) in [str, int]:
+            return int(template)
+        
+        if hasattr(template, 'pk'):
+            return int(template.pk)
+        
+        raise ValueError(f"Provided report template is not a valid type: {type(template)}")
+
+    def printReport(self, report, destination=None, *args, **kwargs):
         """Print the report belonging to the given item.
 
         Set the report with 'report' argument, as the ID of the corresponding
@@ -33,6 +45,30 @@ class ReportPrintingMixin:
 
         If neither plugin nor destination is given, nothing will be done
         """
+
+        if self._api.api_version < MODERN_LABEL_PRINTING_API:
+            return self.printReportLegacy(report, destination, *args, **kwargs)
+
+        print_url = '/report/print/'        
+        template_id = self.getTemplateId(report)
+
+        response = self._api.post(
+            print_url,
+            {
+                'template': template_id,
+                'items': [self.pk],
+            }
+        )
+
+        output = response.get('output', None)
+
+        if output and destination:
+            return self._api.downloadFile(url=output, destination=destination, *args, **kwargs)
+        else:
+            return response
+
+    def printReportLegacy(self, report, destination, *args, **kwargs):
+        """Print the report template against the legacy API."""
 
         if isinstance(report, (ReportBoM, ReportBuild, ReportPurchaseOrder, ReportSalesOrder, ReportReturnOrder, ReportStockLocation, ReportTest)):
             report_id = report.pk
@@ -49,6 +85,10 @@ class ReportPrintingMixin:
         # Use downloadFile method to get the file
         return self._api.downloadFile(url=URL, destination=destination, params=params, *args, **kwargs)
 
+    def getReportTemplates(self, **kwargs):
+        """Return a list of report templates which match this model class."""
+
+        return ReportTemplate.list(self._api, model_type=self.MODEL_TYPE, **kwargs)
 
 class ReportFunctions(inventree.base.MetadataMixin, inventree.base.InventreeObject):
     """Base class for report functions"""
@@ -124,34 +164,46 @@ class ReportFunctions(inventree.base.MetadataMixin, inventree.base.InventreeObje
         return self._api.downloadFile(url=self._data['template'], destination=destination, overwrite=overwrite)
 
 
+
+class ReportTemplate(ReportFunctions):
+    """Class representing the ReportTemplatel model."""
+
+    URL = 'report/template'
+    MIN_API_VERSION = MODERN_LABEL_PRINTING_API
+
+
 class ReportBoM(ReportFunctions):
     """Class representing ReportBoM"""
 
     URL = 'report/bom'
-
+    MAX_API_VERSION = MODERN_LABEL_PRINTING_API
 
 class ReportBuild(ReportFunctions):
     """Class representing ReportBuild"""
 
     URL = 'report/build'
+    MAX_API_VERSION = MODERN_LABEL_PRINTING_API
 
 
 class ReportPurchaseOrder(ReportFunctions):
     """Class representing ReportPurchaseOrder"""
 
     URL = 'report/po'
+    MAX_API_VERSION = MODERN_LABEL_PRINTING_API
 
 
 class ReportSalesOrder(ReportFunctions):
     """Class representing ReportSalesOrder"""
 
     URL = 'report/so'
+    MAX_API_VERSION = MODERN_LABEL_PRINTING_API
 
 
 class ReportReturnOrder(ReportFunctions):
     """Class representing ReportReturnOrder"""
 
     URL = 'report/ro'
+    MAX_API_VERSION = MODERN_LABEL_PRINTING_API
 
 
 class ReportStockLocation(ReportFunctions):
@@ -161,9 +213,11 @@ class ReportStockLocation(ReportFunctions):
     # The closest API version which has the SLR report is 128
     MIN_API_VERSION = 128
     URL = 'report/slr'
+    MAX_API_VERSION = MODERN_LABEL_PRINTING_API
 
 
 class ReportTest(ReportFunctions):
     """Class representing ReportTest"""
 
     URL = 'report/test'
+    MAX_API_VERSION = MODERN_LABEL_PRINTING_API

--- a/inventree/return_order.py
+++ b/inventree/return_order.py
@@ -14,7 +14,7 @@ class ReturnOrderAttachment(inventree.base.InventreeObject):
 
     URL = 'order/ro/attachment'
     ATTACH_TO = 'order'
-    REQUIRED_API_VERSION = 104
+    MIN_API_VERSION = 104
 
 
 class ReturnOrder(
@@ -27,7 +27,7 @@ class ReturnOrder(
     """Class representing the ReturnOrder database model"""
 
     URL = 'order/ro'
-    REQUIRED_API_VERSION = 104
+    MIN_API_VERSION = 104
 
     # Setup for Report mixin
     REPORTNAME = 'ro'
@@ -79,7 +79,7 @@ class ReturnOrderLineItem(inventree.base.InventreeObject):
     """Class representing the ReturnOrderLineItem model"""
 
     URL = 'order/ro-line/'
-    REQUIRED_API_VERSION = 104
+    MIN_API_VERSION = 104
 
     def getOrder(self):
         """Return the ReturnOrder to which this ReturnOrderLineItem belongs"""
@@ -94,7 +94,7 @@ class ReturnOrderExtraLineItem(inventree.base.InventreeObject):
     """Class representing the ReturnOrderExtraLineItem model"""
 
     URL = 'order/ro-extra-line/'
-    REQUIRED_API_VERSION = 104
+    MIN_API_VERSION = 104
 
     def getOrder(self):
         """Return the ReturnOrder to which this line item belongs"""

--- a/inventree/return_order.py
+++ b/inventree/return_order.py
@@ -28,6 +28,7 @@ class ReturnOrder(
 
     URL = 'order/ro'
     MIN_API_VERSION = 104
+    MODEL_TYPE = 'returnorder'
 
     # Setup for Report mixin
     REPORTNAME = 'ro'

--- a/inventree/sales_order.py
+++ b/inventree/sales_order.py
@@ -25,6 +25,7 @@ class SalesOrder(
     """ Class representing the SalesOrder database model """
 
     URL = 'order/so'
+    MODEL_TYPE = 'salesorder'
 
     # Setup for Report mixin
     REPORTNAME = 'so'

--- a/inventree/stock.py
+++ b/inventree/stock.py
@@ -22,6 +22,8 @@ class StockLocation(
 
     URL = 'stock/location'
 
+    MODEL_TYPE = 'stocklocation'
+
     # Setup for Label printing
     LABELNAME = 'location'
     LABELITEM = 'locations'
@@ -69,6 +71,8 @@ class StockItem(
     """Class representing the StockItem database model."""
 
     URL = 'stock'
+
+    MODEL_TYPE = 'stockitem'
 
     # Setup for Label printing
     LABELNAME = 'stock'

--- a/test/test_label.py
+++ b/test/test_label.py
@@ -8,6 +8,7 @@ sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 from test_api import InvenTreeTestCase  # noqa: E402
 
 from inventree.label import LabelTemplate  # noqa: E402
+from inventree.label import MODERN_LABEL_PRINTING_API  # noqa: E402
 from inventree.part import Part  # noqa: E402
 from inventree.plugin import InvenTreePlugin  # noqa: E402
 
@@ -17,6 +18,10 @@ class LabelTemplateTests(InvenTreeTestCase):
 
     def test_label_template_list(self):
         """List available label templates."""
+
+        # Test only for the modern API
+        if self.api.api_version < MODERN_LABEL_PRINTING_API:
+            return
 
         n = LabelTemplate.count(self.api)
         templates = LabelTemplate.list(self.api)
@@ -47,6 +52,10 @@ class LabelTemplateTests(InvenTreeTestCase):
 
     def test_label_print(self):
         """Print a template!"""
+
+        # Test only for the modern API
+        if self.api.api_version < MODERN_LABEL_PRINTING_API:
+            return
 
         # Find a part to print
         part = Part.list(self.api, limit=1)[0]

--- a/test/test_label.py
+++ b/test/test_label.py
@@ -9,7 +9,8 @@ from test_api import InvenTreeTestCase  # noqa: E402
 
 from inventree.label import LabelTemplate  # noqa: E402
 from inventree.part import Part  # noqa: E402
-from inventree.plugin import InvenTreePlugin
+from inventree.plugin import InvenTreePlugin  # noqa: E402
+
 
 class LabelTemplateTests(InvenTreeTestCase):
     """Unit tests for label templates and printing, using the modern API."""
@@ -32,7 +33,7 @@ class LabelTemplateTests(InvenTreeTestCase):
             enabled = idx > 0
 
             if template.enabled != enabled:
-                template.save(data = {'enabled': idx > 0})
+                template.save(data={'enabled': idx > 0})
 
         # Filter by 'enabled' status
         templates = LabelTemplate.list(self.api, enabled=True)

--- a/test/test_label.py
+++ b/test/test_label.py
@@ -7,208 +7,67 @@ sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 
 from test_api import InvenTreeTestCase  # noqa: E402
 
-from inventree.label import LabelLocation, LabelPart, LabelStock  # noqa: E402
+from inventree.label import LabelTemplate  # noqa: E402
 from inventree.part import Part  # noqa: E402
-from inventree.stock import StockItem, StockLocation  # noqa: E402
+from inventree.plugin import InvenTreePlugin
 
+class LabelTemplateTests(InvenTreeTestCase):
+    """Unit tests for label templates and printing, using the modern API."""
 
-class LabelTest(InvenTreeTestCase):
-    """Tests for Label functions models"""
+    def test_label_template_list(self):
+        """List available label templates."""
 
-    def test_label_list(self):
-        """
-        Test for using listing functionality of each type of label
-        """
+        n = LabelTemplate.count(self.api)
+        templates = LabelTemplate.list(self.api)
 
-        # Parts
-        # Get label list
-        lbl_part_list = LabelPart.list(self.api)
+        self.assertEqual(n, len(templates))
+        self.assertGreater(len(templates), 0)
 
-        # Make a new list filtered by LabelPart
-        # List should be non-zero length
-        # Filtered list should be equal the original list
-        lbl_part_list_filtered = [x for x in lbl_part_list if isinstance(x, LabelPart)]
+        # Check some expected attributes
+        for attr in ['name', 'description', 'enabled', 'model_type', 'template']:
+            for template in templates:
+                self.assertIn(attr, template)
 
-        self.assertGreater(len(lbl_part_list_filtered), 0)
-        self.assertEqual(lbl_part_list, lbl_part_list_filtered)
+        for idx, template in enumerate(templates):
+            enabled = idx > 0
 
-        # Stock Items
-        # Get label list
-        lbl_stock_list = LabelStock.list(self.api)
+            if template.enabled != enabled:
+                template.save(data = {'enabled': idx > 0})
 
-        # Make a new list filtered by LabelPart
-        # List should be non-zero length
-        # Filtered list should be equal the original list
-        lbl_stock_list_filtered = [x for x in lbl_stock_list if isinstance(x, LabelStock)]
+        # Filter by 'enabled' status
+        templates = LabelTemplate.list(self.api, enabled=True)
+        self.assertGreater(len(templates), 0)
+        self.assertLess(len(templates), n)
 
-        self.assertGreater(len(lbl_stock_list_filtered), 0)
-        self.assertEqual(lbl_stock_list, lbl_stock_list_filtered)
+        # Filter by 'disabled' status
+        templates = LabelTemplate.list(self.api, enabled=False)
+        self.assertGreater(len(templates), 0)
+        self.assertLess(len(templates), n)
 
-        # Stock Locations
-        # Get label list
-        lbl_location_list = LabelLocation.list(self.api)
+    def test_label_print(self):
+        """Print a template!"""
 
-        # Make a new list filtered by LabelPart
-        # List should be non-zero length
-        # Filtered list should be equal the original list
-        lbl_location_list_filtered = [x for x in lbl_location_list if isinstance(x, LabelLocation)]
+        # Find a part to print
+        part = Part.list(self.api, limit=1)[0]
 
-        self.assertGreater(len(lbl_location_list_filtered), 0)
-        self.assertEqual(lbl_location_list, lbl_location_list_filtered)
+        templates = part.getLabelTemplates()
+        self.assertGreater(len(templates), 0)
 
-    def test_label_create_download(self):
-        """
-        Tests creating a new label from API, by uploading the dummy template file
-        """
+        template = templates[0]
 
-        def comparefiles(file1, file2):
-            """Compare content of two files, return True if equal, else False"""
+        # Find an available plugin
+        plugins = InvenTreePlugin.list(self.api, active=True, mixin='labels')
+        self.assertGreater(len(plugins), 0)
 
-            F1 = open(file1, 'r')
-            contents_1 = F1.read()
-            F1.close()
+        plugin = plugins[0]
 
-            F2 = open(file2, 'r')
-            contents_2 = F2.read()
-            F2.close()
+        response = part.printLabel(label=template, plugin=plugin)
 
-            return contents_1 == contents_2
-
-        dummytemplate = os.path.join(os.path.dirname(__file__), 'dummytemplate.html')
-        dummytemplate2 = os.path.join(os.path.dirname(__file__), 'dummytemplate2.html')
-
-        for RepClass in (LabelPart, LabelStock, LabelLocation):
-            # Test for all Label classes sequentially
-
-            #
-            # Test with file name
-            #
-
-            # Create a new label based on the dummy template
-            newlabel = RepClass.create(
-                self.api,
-                {'name': 'Dummy label', 'description': 'Label created as test'},
-                dummytemplate
-            )
-
-            # The return value should be a LabelPart object
-            self.assertIsInstance(newlabel, RepClass)
-
-            # Try to download the template file
-            newlabel.downloadTemplate(destination="dummytemplate_download.html")
-
-            self.assertTrue(comparefiles("dummytemplate_download.html", dummytemplate))
-
-            # Remove the test file
-            os.remove("dummytemplate_download.html")
-
-            #
-            # Test with open(...)
-            #
-
-            # Create a new label based on the dummy template
-            with open(dummytemplate) as template_upload:
-                newlabel2 = RepClass.create(
-                    self.api,
-                    {'name': 'Dummy label', 'description': 'Label created as test'},
-                    template_upload
-                )
-
-            # The return value should be a LabelPart object
-            self.assertIsInstance(newlabel2, RepClass)
-
-            # Try to download the template file
-            newlabel2.downloadTemplate(destination="dummytemplate_download.html")
-
-            self.assertTrue(comparefiles("dummytemplate_download.html", dummytemplate))
-
-            # Remove the test file
-            os.remove("dummytemplate_download.html")
-
-            #
-            # Test overwriting the label file with save method
-            # Use file name
-            #
-
-            newlabel2.save(data=None, label=dummytemplate2)
-
-            # Try to download the template file
-            newlabel2.downloadTemplate(destination="dummytemplate2_download.html")
-
-            self.assertTrue(comparefiles("dummytemplate2_download.html", dummytemplate2))
-            # Remove the test file
-            os.remove("dummytemplate2_download.html")
-
-            #
-            # Test overwriting the template file with save method
-            # Use open(...)
-            #
-
-            with open(dummytemplate) as template_upload:
-                newlabel2.save(data=None, label=template_upload)
-
-            # Try to download the template file
-            newlabel2.downloadTemplate(destination="dummytemplate_download.html")
-
-            self.assertTrue(comparefiles("dummytemplate_download.html", dummytemplate))
-
-            # Remove the test file
-            os.remove("dummytemplate_download.html")
-
-    def test_label_printing(self):
-        """
-        Tests for using label printing function to download PDF files
-        """
-
-        # For each class supporting printing, find a related object
-        # Define a file, write the label to this file
-        # Check for file
-
-        # Parts
-        # Object and label - get first in list
-        prt = Part.list(self.api)[0]
-        lbl_part = LabelPart.list(self.api)[0]
-
-        # Attempt to print to file - use label object
-        self.assertTrue(prt.printlabel(label=lbl_part, plugin=None, destination="partlabel_1.pdf"))
-
-        # Attempt to print to file - use label ID directly
-        self.assertTrue(prt.printlabel(label=lbl_part.pk, plugin=None, destination="partlabel_2.pdf"))
-
-        # Make sure the files exist
-        self.assertTrue(os.path.isfile("partlabel_1.pdf"))
-        self.assertTrue(os.path.isfile("partlabel_2.pdf"))
-        os.remove("partlabel_1.pdf")
-        os.remove("partlabel_2.pdf")
-
-        # StockItem
-        # Object and label - get first in list
-        sti = StockItem.list(self.api)[0]
-        lbl_sti = LabelStock.list(self.api)[0]
-
-        # Attempt to print to file - use label object
-        sti.printlabel(label=lbl_sti, plugin=None, destination="stocklabel_1.pdf")
-        # Attempt to print to file - use label ID directly
-        sti.printlabel(label=lbl_sti.pk, plugin=None, destination="stocklabel_2.pdf")
-
-        # Make sure the files exist
-        self.assertTrue(os.path.isfile("stocklabel_1.pdf"))
-        self.assertTrue(os.path.isfile("stocklabel_2.pdf"))
-        os.remove("stocklabel_1.pdf")
-        os.remove("stocklabel_2.pdf")
-
-        # StockLocation
-        # Object and label - get first in list
-        sloc = StockLocation.list(self.api)[0]
-        lbl_sloc = LabelLocation.list(self.api)[0]
-
-        # Attempt to print to file - use label object
-        sloc.printlabel(label=lbl_sloc, plugin=None, destination="locationlabel_1.pdf")
-        # Attempt to print to file - use label ID directly
-        sloc.printlabel(label=lbl_sloc.pk, plugin=None, destination="locationlabel_2.pdf")
-
-        # Make sure the files exist
-        self.assertTrue(os.path.isfile("locationlabel_1.pdf"))
-        self.assertTrue(os.path.isfile("locationlabel_2.pdf"))
-        os.remove("locationlabel_1.pdf")
-        os.remove("locationlabel_2.pdf")
+        for key in ['created', 'model_type', 'complete', 'output', 'template', 'plugin']:
+            self.assertIn(key, response)
+        
+        self.assertEqual(response['complete'], True)
+        self.assertEqual(response['model_type'], 'part')
+        self.assertIsNotNone(response['output'])
+        self.assertEqual(response['template'], template.pk)
+        self.assertEqual(response['plugin'], plugin.key)

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -41,14 +41,10 @@ class PluginTest(InvenTreeTestCase):
         plugins = InvenTreePlugin.list(self.api, active=True)
         self.assertGreater(len(plugins), 0)
 
+        plugin = plugins[0]
+
         for plugin in plugins:
             self.assertTrue(plugin.active)
-
-        plugins = InvenTreePlugin.list(self.api, active=False)
-        self.assertGreater(len(plugins), 0)
-
-        for plugin in plugins:
-            self.assertFalse(plugin.active)
 
     def test_filter_by_builtin(self):
         """Filter by plugin builtin status."""

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -7,7 +7,8 @@ sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 
 from test_api import InvenTreeTestCase  # noqa: E402
 
-from inventree.plugin import InvenTreePlugin
+from inventree.plugin import InvenTreePlugin  # noqa: E402
+
 
 class PluginTest(InvenTreeTestCase):
     """Unit tests for plugin functionality."""
@@ -33,7 +34,6 @@ class PluginTest(InvenTreeTestCase):
         for plugin in plugins:
             for key in expected_attributes:
                 self.assertIn(key, plugin)
-
 
     def test_filter_by_active(self):
         """Filter by plugin active status."""

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -17,6 +17,63 @@ class PluginTest(InvenTreeTestCase):
 
         plugins = InvenTreePlugin.list(self.api)
 
-        for plugin in plugins:
-            print(plugin._data)
+        expected_attributes = [
+            'pk',
+            'key',
+            'name',
+            'package_name',
+            'active',
+            'meta',
+            'mixins',
+            'is_builtin',
+            'is_sample',
+            'is_installed'
+        ]
 
+        for plugin in plugins:
+            for key in expected_attributes:
+                self.assertIn(key, plugin)
+
+
+    def test_filter_by_active(self):
+        """Filter by plugin active status."""
+
+        plugins = InvenTreePlugin.list(self.api, active=True)
+        self.assertGreater(len(plugins), 0)
+
+        for plugin in plugins:
+            self.assertTrue(plugin.active)
+
+        plugins = InvenTreePlugin.list(self.api, active=False)
+        self.assertGreater(len(plugins), 0)
+
+        for plugin in plugins:
+            self.assertFalse(plugin.active)
+
+    def test_filter_by_builtin(self):
+        """Filter by plugin builtin status."""
+
+        plugins = InvenTreePlugin.list(self.api, builtin=True)
+        self.assertGreater(len(plugins), 0)
+
+        for plugin in plugins:
+            self.assertTrue(plugin.is_builtin)
+        
+        plugins = InvenTreePlugin.list(self.api, builtin=False)
+        self.assertGreater(len(plugins), 0)
+
+        for plugin in plugins:
+            self.assertFalse(plugin.is_builtin)
+    
+    def test_filter_by_mixin(self):
+        """Test that we can filter by 'mixin' attribute."""
+
+        n = InvenTreePlugin.count(self.api)
+
+        plugins = InvenTreePlugin.list(self.api, mixin='labels')
+
+        self.assertLess(len(plugins), n)
+        self.assertGreater(len(plugins), 0)
+
+        for plugin in plugins:
+            self.assertIn('labels', plugin.mixins)

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -54,12 +54,6 @@ class PluginTest(InvenTreeTestCase):
 
         for plugin in plugins:
             self.assertTrue(plugin.is_builtin)
-        
-        plugins = InvenTreePlugin.list(self.api, builtin=False)
-        self.assertGreater(len(plugins), 0)
-
-        for plugin in plugins:
-            self.assertFalse(plugin.is_builtin)
     
     def test_filter_by_mixin(self):
         """Test that we can filter by 'mixin' attribute."""

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.dirname(__file__)))
+
+from test_api import InvenTreeTestCase  # noqa: E402
+
+from inventree.plugin import InvenTreePlugin
+
+class PluginTest(InvenTreeTestCase):
+    """Unit tests for plugin functionality."""
+
+    def test_plugin_list(self):
+        """Test plugin list API."""
+
+        plugins = InvenTreePlugin.list(self.api)
+
+        for plugin in plugins:
+            print(plugin._data)
+

--- a/test/test_report.py
+++ b/test/test_report.py
@@ -9,6 +9,7 @@ from test_api import InvenTreeTestCase  # noqa: E402
 
 from inventree.build import Build  # noqa: E402
 from inventree.report import ReportTemplate  # noqa: E402
+from inventree.report import MODERN_LABEL_PRINTING_API  # noqa: E402
 
 
 class ReportClassesTest(InvenTreeTestCase):
@@ -16,6 +17,10 @@ class ReportClassesTest(InvenTreeTestCase):
 
     def test_list_templates(self):
         """List the available report templates."""
+
+        # Test only for the modern API
+        if self.api.api_version < MODERN_LABEL_PRINTING_API:
+            return
 
         templates = ReportTemplate.list(self.api)
 
@@ -39,6 +44,10 @@ class ReportClassesTest(InvenTreeTestCase):
     
     def test_print_report(self):
         """Test report printing."""
+
+        # Test only for the modern API
+        if self.api.api_version < MODERN_LABEL_PRINTING_API:
+            return
 
         # Find a build to print
         build = Build.list(self.api, limit=1)[0]

--- a/test/test_report.py
+++ b/test/test_report.py
@@ -8,177 +8,51 @@ sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 from test_api import InvenTreeTestCase  # noqa: E402
 
 from inventree.build import Build  # noqa: E402
-from inventree.part import BomItem  # noqa: E402
-from inventree.purchase_order import PurchaseOrder  # noqa: E402
-from inventree.report import (ReportBoM, ReportBuild,  # noqa: E402
-                              ReportPurchaseOrder, ReportReturnOrder,
-                              ReportSalesOrder, ReportStockLocation,
-                              ReportTest)
-from inventree.return_order import ReturnOrder  # noqa: E402
-from inventree.sales_order import SalesOrder  # noqa: E402
-from inventree.stock import StockItemTestResult, StockLocation  # noqa: E402
-
+from inventree.report import ReportTemplate  # noqa: E402
 
 class ReportClassesTest(InvenTreeTestCase):
     """Tests for Report functions models"""
 
-    def test_report_list(self):
-        """
-        Test for using listing functionality of each type of label
-        """
+    def test_list_templates(self):
+        """List the available report templates."""
 
-        for RepClass in (ReportBoM, ReportBuild, ReportPurchaseOrder, ReportSalesOrder, ReportReturnOrder, ReportStockLocation, ReportTest):
-            # Get report list
-            report_list = RepClass.list(self.api)
+        templates = ReportTemplate.list(self.api)
 
-            # Make a new list filtered by LabelPart
-            # List should be non-zero length
-            # Filtered list should be equal the original list
-            report_list_filtered = [x for x in report_list if isinstance(x, RepClass)]
+        self.assertGreater(len(templates), 0)
 
-            self.assertGreater(len(report_list_filtered), 0)
-            self.assertEqual(report_list, report_list_filtered)
+        for template in templates:
+            for key in ['name', 'description', 'enabled', 'model_type', 'template']:
+                self.assertIn(key, template)
 
-    def test_report_create_download(self):
-        """
-        Tests creating a new report from API, by uploading the dummy template file
-        """
+        # disable a template
+        templates[0].save(data={'enabled': False})
 
-        def comparefiles(file1, file2):
-            """Compare content of two files, return True if equal, else False"""
+        templates = ReportTemplate.list(self.api, enabled=False)
+        self.assertGreater(len(templates), 0)
 
-            F1 = open(file1, 'r')
-            contents_1 = F1.read()
-            F1.close()
+        # enable a template
+        templates[0].save(data={'enabled': True})
+        
+        templates = ReportTemplate.list(self.api, enabled=True)
+        self.assertGreater(len(templates), 0)
+    
+    def test_print_report(self):
+        """Test report printing."""
 
-            F2 = open(file2, 'r')
-            contents_2 = F2.read()
-            F2.close()
+        # Find a build to print
+        build = Build.list(self.api, limit=1)[0]
 
-            return contents_1 == contents_2
+        templates = build.getReportTemplates()
+        self.assertGreater(len(templates), 0)
 
-        dummytemplate = os.path.join(os.path.dirname(__file__), 'dummytemplate.html')
-        dummytemplate2 = os.path.join(os.path.dirname(__file__), 'dummytemplate2.html')
+        template = templates[0]
 
-        # Not testing ReportBuild, since a bug (https://github.com/inventree/InvenTree/issues/6213) prevents the PATCH
-        # method from working
-        for RepClass in (ReportBoM, ReportPurchaseOrder, ReportSalesOrder, ReportReturnOrder, ReportStockLocation, ReportTest):
-            # Test for all Label classes sequentially
+        # Print the report
+        response = build.printReport(template)
 
-            #
-            # Test with file name
-            #
-
-            # Create a new label based on the dummy template
-            newreport = RepClass.create(
-                self.api,
-                {'name': 'Dummy report', 'description': 'Report created as test'},
-                dummytemplate
-            )
-
-            # The return value should be a LabelPart object
-            self.assertIsInstance(newreport, RepClass)
-
-            # Try to download the template file
-            newreport.downloadTemplate(destination="dummytemplate_download.html")
-
-            # Compare file contents, make sure they're the same
-            self.assertTrue(comparefiles("dummytemplate_download.html", dummytemplate))
-
-            # Remove the test file
-            os.remove("dummytemplate_download.html")
-
-            #
-            # Test with open(...)
-            #
-
-            # Create a new label based on the dummy template
-            with open(dummytemplate) as template_upload:
-                newreport2 = RepClass.create(
-                    self.api,
-                    {'name': 'Dummy report', 'description': 'Report created as test'},
-                    template_upload
-                )
-
-            # The return value should be a LabelPart object
-            self.assertIsInstance(newreport2, RepClass)
-
-            # Try to download the template file
-            newreport2.downloadTemplate(destination="dummytemplate_download.html")
-
-            # Compare file contents, make sure they're the same
-            # Compare file contents, make sure they're the same
-            self.assertTrue(comparefiles("dummytemplate_download.html", dummytemplate))
-
-            # Remove the test file
-            os.remove("dummytemplate_download.html")
-
-            #
-            # Test overwriting the label file with save method
-            # Use file name
-            #
-            newreport2.save(data=None, template=dummytemplate2)
-
-            # Try to download the template file
-            newreport2.downloadTemplate(destination="dummytemplate2_download.html")
-
-            # Compare file contents, make sure they're the same
-            self.assertTrue(comparefiles("dummytemplate2_download.html", dummytemplate2))
-
-            # Remove the test file
-            os.remove("dummytemplate2_download.html")
-
-            #
-            # Test overwriting the template file with save method
-            # Use open(...)
-            #
-
-            with open(dummytemplate) as template_upload:
-                newreport2.save(data=None, template=template_upload)
-
-            # Try to download the template file
-            newreport2.downloadTemplate(destination="dummytemplate_download.html")
-
-            # Compare file contents, make sure they're the same
-            self.assertTrue(comparefiles("dummytemplate_download.html", dummytemplate))
-
-            # Remove the test file
-            os.remove("dummytemplate_download.html")
-
-    def test_report_printing(self):
-        """
-        Tests for using report printing function to download PDF files
-        """
-
-        # For each class supporting reports, find a related object
-        # Define a file, write the label to this file
-        # Check for file
-
-        testscount = 0
-
-        for ItemModel, RepClass in zip(
-                (BomItem, Build, PurchaseOrder, SalesOrder, ReturnOrder, StockLocation, StockItemTestResult),
-                (ReportBoM, ReportBuild, ReportPurchaseOrder, ReportSalesOrder, ReportReturnOrder, ReportStockLocation, ReportTest)
-        ):
-
-            # Item and report - get first in list
-            itmlist = ItemModel.list(self.api)
-            replist = RepClass.list(self.api)
-
-            # The test can only be carried out if there are items and reports defined
-            if len(itmlist) > 0 and len(replist) > 0:
-                itm = itmlist[0]
-                rep = replist[0]
-
-                # Attempt to print to file - use label object
-                self.assertTrue(itm.printreport(report=rep, destination="report.pdf"))
-
-                # Make sure the files exist
-                self.assertTrue(os.path.isfile("report.pdf"))
-
-                os.remove("report.pdf")
-
-                testscount += 1
-
-        # Make sure we actually tested something
-        assert testscount > 0
+        for key in ['pk', 'model_type', 'output', 'template']:
+            self.assertIn(key, response)
+        
+        self.assertIsNotNone(response['output'])
+        self.assertEqual(response['template'], template.pk)
+        self.assertEqual(response['model_type'], build.getModelType())

--- a/test/test_report.py
+++ b/test/test_report.py
@@ -10,6 +10,7 @@ from test_api import InvenTreeTestCase  # noqa: E402
 from inventree.build import Build  # noqa: E402
 from inventree.report import ReportTemplate  # noqa: E402
 
+
 class ReportClassesTest(InvenTreeTestCase):
     """Tests for Report functions models"""
 
@@ -32,7 +33,7 @@ class ReportClassesTest(InvenTreeTestCase):
 
         # enable a template
         templates[0].save(data={'enabled': True})
-        
+
         templates = ReportTemplate.list(self.api, enabled=True)
         self.assertGreater(len(templates), 0)
     


### PR DESCRIPTION
Working on a new implementation of label and report printing, to match the updated API version:

Ref: https://github.com/inventree/InvenTree/pull/7074

The intent here is that both "modern" and "legacy" API versions will be supported concurrently, at least until we decide to deprecate the "old" API in the future.

### TODO

- [x] Add model class for plugin support
- [x] Update label printing classes
- [x] Update unit tests for label printing
- [x] Update report printing classes
- [x] Update unit tests for report printing