### PR TITLE
Fix for list which raises an error

### DIFF
--- a/inventree/base.py
+++ b/inventree/base.py
@@ -2,11 +2,12 @@
 
 import json
 import logging
+import requests
 import os
 
 from . import api as inventree_api
 
-INVENTREE_PYTHON_VERSION = "0.17.1"
+INVENTREE_PYTHON_VERSION = "0.17.2"
 
 
 logger = logging.getLogger('inventree')
@@ -231,10 +232,15 @@ class InventreeObject(object):
         else:
             url = cls.URL
 
-        response = api.get(url=url, params=kwargs)
+        try:
+            response = api.get(url=url, params=kwargs)
+        except requests.exceptions.HTTPError as e:
+            logger.error(f"Error during list request: {e}")
+            # Return an empty list
+            return []
 
         if response is None:
-            return None
+            return []
 
         items = []
 

--- a/inventree/base.py
+++ b/inventree/base.py
@@ -237,7 +237,13 @@ class InventreeObject(object):
         except requests.exceptions.HTTPError as e:
             logger.error(f"Error during list request: {e}")
             # Return an empty list
-            return []
+
+            raise_error = kwargs.get('raise_error', False)
+
+            if raise_error:
+                raise e
+            else:
+                return []
 
         if response is None:
             return []

--- a/test/test_order.py
+++ b/test/test_order.py
@@ -401,6 +401,14 @@ class POTest(InvenTreeTestCase):
         results = order.PurchaseOrder.list(self.api, project_code=999999999)
         self.assertEqual(len(results), 0)
 
+        # Try the same again, but raise the eror
+        with self.assertRaises(HTTPError):
+            results = order.PurchaseOrder.list(
+                self.api,
+                project_code=999999999,
+                raise_error=True
+            )
+
         # Find a valid project code
         n = ProjectCode.count(self.api)
 

--- a/test/test_order.py
+++ b/test/test_order.py
@@ -390,6 +390,34 @@ class POTest(InvenTreeTestCase):
         attachments = po.getAttachments()
         self.assertEqual(len(attachments), 3)
 
+    def test_invalid_list(self):
+        """Test list with an invalid parameter.
+        
+        Ref: https://github.com/inventree/inventree-python/issues/246
+        """
+
+        from inventree.project_code import ProjectCode
+
+        results = order.PurchaseOrder.list(self.api, project_code=999999999)
+        self.assertEqual(len(results), 0)
+
+        # Find a valid project code
+        n = ProjectCode.count(self.api)
+
+        # Create a new project code
+        pc = ProjectCode.create(self.api, {
+            'code': f"TEST-{n+1}",
+            'description': 'Test project code',
+        })
+
+        # Attach project code to an order
+        po = order.PurchaseOrder.list(self.api, limit=1)[0]
+        po.save({'project_code': pc.pk})
+
+        # Now, list orders with the project code
+        results = order.PurchaseOrder.list(self.api, project_code=pc.pk)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].pk, po.pk)
 
 class SOTest(InvenTreeTestCase):
     """

--- a/test/test_order.py
+++ b/test/test_order.py
@@ -427,6 +427,7 @@ class POTest(InvenTreeTestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].pk, po.pk)
 
+
 class SOTest(InvenTreeTestCase):
     """
     Unit test for SalesOrder


### PR DESCRIPTION
- Closes https://github.com/inventree/inventree-python/issues/246
- Handles an error thrown during a `list()` call, and returns an empty list