### PR TITLE
Improve compatibility with older versionof InvenTree Server.

### DIFF
--- a/inventree/sales_order.py
+++ b/inventree/sales_order.py
@@ -196,6 +196,7 @@ class SalesOrderAllocation(
 ):
     """Class representing the SalesOrderAllocation database model."""
 
+    MIN_API_VERSION = 267
     URL = 'order/so-allocation'
 
     def getOrder(self):
@@ -204,7 +205,7 @@ class SalesOrderAllocation(
 
     def getShipment(self):
         """Return the SalesOrderShipment to which this SalesOrderAllocation belongs."""
-        from sales_order import SalesOrderShipment
+        # from sales_order import SalesOrderShipment
         return SalesOrderShipment(self._api, self.shipment)
 
     def getLineItem(self):
@@ -275,7 +276,10 @@ class SalesOrderShipment(
 
         Note: This is an overload of getAllocations() method, for legacy compatibility.
         """
-        return self.getAllocations()
+        try:
+            return self.getAllocations()
+        except NotImplementedError:
+            return self._data['allocations']
 
     def complete(
         self,

--- a/inventree/sales_order.py
+++ b/inventree/sales_order.py
@@ -205,7 +205,7 @@ class SalesOrderAllocation(
 
     def getShipment(self):
         """Return the SalesOrderShipment to which this SalesOrderAllocation belongs."""
-        # from sales_order import SalesOrderShipment
+        from sales_order import SalesOrderShipment
         return SalesOrderShipment(self._api, self.shipment)
 
     def getLineItem(self):


### PR DESCRIPTION
This commit:
- adds MIN_API_VERSION to SalesOrderAllocation model
- adds a workaround for older versions of InvenTree server, allowing use of the old `allocations` data.

See https://github.com/inventree/inventree-python/issues/250 for explanation.