### PR TITLE
Using Cached Session for all API Requests to reduce the amount of DNS…

### DIFF
--- a/inventree/api.py
+++ b/inventree/api.py
@@ -14,6 +14,8 @@ import requests
 from requests.auth import HTTPBasicAuth
 from requests.exceptions import Timeout
 
+from requests_cache import CachedSession
+
 logger = logging.getLogger('inventree')
 
 
@@ -291,13 +293,15 @@ class InvenTreeAPI(object):
         # Use provided HTTP method
         method = kwargs.get('method', 'get')
 
+        session = CachedSession('inventree_api')
+
         methods = {
-            'GET': requests.get,
-            'POST': requests.post,
-            'PUT': requests.put,
-            'PATCH': requests.patch,
-            'DELETE': requests.delete,
-            'OPTIONS': requests.options,
+            'GET': session.get,
+            'POST': session.post,
+            'PUT': session.put,
+            'PATCH': session.patch,
+            'DELETE': session.delete,
+            'OPTIONS': session.options,
         }
 
         if method.upper() not in methods.keys():

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ invoke>=1.4.0
 coverage>=6.4.1                 # Run tests, measure coverage
 coveralls>=3.3.1
 Pillow>=9.1.1
+requests-cache>=1.2.1


### PR DESCRIPTION
#252 Adding Cached Sessions from python package `requests_cache` to reduce DNS queries.