### PR TITLE
Handle list returns from creating StockItems

### DIFF
--- a/test/test_api.py
+++ b/test/test_api.py
@@ -209,8 +209,7 @@ class TestCreate(InvenTreeTestCase):
             'part': p.pk,
             'quantity': 45,
             'notes': 'This is a note',
-
-        })
+        })[0]
 
         self.assertIsNotNone(s)
         self.assertEqual(s.part, p.pk)

--- a/test/test_stock.py
+++ b/test/test_stock.py
@@ -248,6 +248,25 @@ class StockTest(InvenTreeTestCase):
 
             item.unassignBarcode()
 
+    def test_serialized(self):
+        """Test serializing multiple objects on create"""
+
+        # Create items with serial numbers
+        items = StockItem.create(
+            self.api,
+            {
+                "part": 10004,
+                "quantity": 3,
+                "serial_numbers": "1005,1006,1007"
+            }
+        )
+
+        self.assertEqual(3, len(items))
+
+        self.assertEqual('1005', items[0].serial)
+        self.assertEqual('1006', items[1].serial)
+        self.assertEqual('1007', items[2].serial)
+
 
 class StockAdjustTest(InvenTreeTestCase):
     """Unit tests for stock 'adjustment' actions"""

--- a/test/test_stock.py
+++ b/test/test_stock.py
@@ -426,6 +426,10 @@ class StockAdjustTest(InvenTreeTestCase):
             }
         )
 
+        # Verify a single result was returned
+        self.assertEqual(1, len(assignitem))
+        assignitem = assignitem[0]
+
         # Assign the item
         assignitem.assignStock(customer=customer, notes='Sell on the side')
 


### PR DESCRIPTION
Since inventree/InvenTree#9857 the `StockItem` create API has been able to return multiple items for a single call. The python API was not updated to handle this (as tested by the first commit on this branch), which blocked my attempt at fixing the annotations to generate a usable API schema (inventree/InvenTree#9969).

Breaking: This PR changes `StockItem` create to always return a list of items.

With these changes both `master` and inventree/InvenTree#9969 are able to pass the API tests.

As always, let me know if anything needs to change to fit Python conventions/project style/etc.