### PR TITLE
Make pip-system-certs an optional extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ The InvenTree python library can be easily installed using PIP:
 pip install inventree
 ```
 
+If you need to rely on system certificates from the OS certificate store instead of the bundled certificates, use
+
+```
+pip install inventree[system-certs]
+```
+
+This allows pip and Python applications to verify TLS/SSL connections to servers whose certificates are trusted by your system, and can be helpful if you're using a custom certificate authority (CA) for your InvenTree instance's cert.
+
 ## Documentation
 
 Refer to the [InvenTree documentation](https://docs.inventree.org/en/latest/api/python/python/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,12 @@ keywords = [
     "stock",
 ]
 dependencies = [
-    "pip-system-certs>=4.0",
-    "requests>=2.27.0",
+    "requests>=2.27.0", 
     "urllib3>=2.3.0",
 ]
+[project.optional-dependencies]
+"system-certs" = ["pip-system-certs>=4.0"]
+
 
 [project.urls]
 Homepage = "https://github.com/inventree/inventree-python/"


### PR DESCRIPTION
fixes #274 

Make `pip-system-certs` an optional dependency, allowing the user to tune the install to fit their environment